### PR TITLE
Add Publishers to Games

### DIFF
--- a/behat/Features/jsonapi/publisher.feature
+++ b/behat/Features/jsonapi/publisher.feature
@@ -1,0 +1,30 @@
+Feature: Publisher
+
+  Scenario: Fetching a publisher with a wrong UUID should return a 404.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher/abcdef"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetching a publisher by his UUID works, fetching it by his NID does not works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher/c16c1119-ae04-460c-9fed-e9e20d5785e7"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher/23"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetch a publisher using UUID should return it in the default language
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher/c16c1119-ae04-460c-9fed-e9e20d5785e7"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON node "data.attributes.langcode" should be equal to "en"
+    And the JSON node "data.attributes.title" should be equal to "Shy Robot Games"
+    And the JSON node "data.attributes.field_path" should be equal to "/publishers/shy-robot-games"
+
+  Scenario: Fetching publisher using the path filter may return one or more results.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher?filter[field_path]=/publishers/shy-robot-games"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.langcode" should be equal to "en"
+    And the JSON node "data.attributes.title" should be equal to "Shy Robot Games"
+    And the JSON node "data.attributes.field_path" should be equal to "/publishers/shy-robot-games"

--- a/behat/Features/jsonapi/publisher.feature
+++ b/behat/Features/jsonapi/publisher.feature
@@ -26,5 +26,5 @@ Feature: Publisher
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "data[0].attributes.langcode" should be equal to "en"
-    And the JSON node "data.attributes.name" should be equal to "Shy Robot Games"
-    And the JSON node "data.attributes.field_path" should be equal to "/publishers/shy-robot-games"
+    And the JSON node "data[0].attributes.name" should be equal to "Shy Robot Games"
+    And the JSON node "data[0].attributes.field_path" should be equal to "/publishers/shy-robot-games"

--- a/behat/Features/jsonapi/publisher.feature
+++ b/behat/Features/jsonapi/publisher.feature
@@ -18,7 +18,7 @@ Feature: Publisher
     Then the response status code should be 200
     And the response should be in JSON
     Then the JSON node "data.attributes.langcode" should be equal to "en"
-    And the JSON node "data.attributes.title" should be equal to "Shy Robot Games"
+    And the JSON node "data.attributes.name" should be equal to "Shy Robot Games"
     And the JSON node "data.attributes.field_path" should be equal to "/publishers/shy-robot-games"
 
   Scenario: Fetching publisher using the path filter may return one or more results.
@@ -26,5 +26,5 @@ Feature: Publisher
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "data[0].attributes.langcode" should be equal to "en"
-    And the JSON node "data.attributes.title" should be equal to "Shy Robot Games"
+    And the JSON node "data.attributes.name" should be equal to "Shy Robot Games"
     And the JSON node "data.attributes.field_path" should be equal to "/publishers/shy-robot-games"

--- a/behat/Features/jsonapi/publishers.feature
+++ b/behat/Features/jsonapi/publishers.feature
@@ -1,0 +1,18 @@
+Feature: Publishers
+
+  Scenario: The list of publisher return only published ones.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data" should have 3 elements
+    And the JSON node "data[0].attributes.name" should be equal to "Shy Robot Games"
+    And the JSON node "data[1].attributes.name" should be equal to "Astragon"
+    And the JSON node "data[2].attributes.name" should be equal to "Focus Home Interactive"
+
+  Scenario: Sorting of publisher listing works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/publisher?sort=name"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.name" should be equal to "Astragon"
+    And the JSON node "data[1].attributes.name" should be equal to "Focus Home Interactive"
+    And the JSON node "data[2].attributes.name" should be equal to "Shy Robot Games"

--- a/config/d8/sync/core.entity_form_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_form_display.node.game.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.game.field_images
     - field.field.node.game.field_members
     - field.field.node.game.field_path
+    - field.field.node.game.field_publishers
     - field.field.node.game.field_releases
     - field.field.node.game.field_studios
     - image.style.thumbnail
@@ -53,6 +54,7 @@ third_party_settings:
       region: content
     group_releases:
       children:
+        - field_publishers
         - field_releases
       parent_name: group_tabs
       weight: 21
@@ -139,8 +141,18 @@ content:
     third_party_settings: {  }
     type: team_member_default
     region: content
+  field_publishers:
+    weight: 124
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   field_releases:
-    weight: 123
+    weight: 125
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/d8/sync/core.entity_form_display.taxonomy_term.publisher.default.yml
+++ b/config/d8/sync/core.entity_form_display.taxonomy_term.publisher.default.yml
@@ -1,0 +1,52 @@
+uuid: d4bfb016-876d-4cc7-8091-1ce8b565ecc4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.publisher.field_path
+    - taxonomy.vocabulary.publisher
+  module:
+    - fieldable_path
+    - path
+    - text
+id: taxonomy_term.publisher.default
+targetEntityType: taxonomy_term
+bundle: publisher
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_path:
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    type: fieldable_path_widget
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/d8/sync/core.entity_view_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.game.field_images
     - field.field.node.game.field_members
     - field.field.node.game.field_path
+    - field.field.node.game.field_publishers
     - field.field.node.game.field_releases
     - field.field.node.game.field_studios
     - node.type.game
@@ -60,6 +61,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: fieldable_path_formatter
+    region: content
+  field_publishers:
+    weight: 108
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_releases:
     weight: 104

--- a/config/d8/sync/core.entity_view_display.node.game.teaser.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.teaser.yml
@@ -5,6 +5,13 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.game.body
+    - field.field.node.game.field_genres
+    - field.field.node.game.field_images
+    - field.field.node.game.field_members
+    - field.field.node.game.field_path
+    - field.field.node.game.field_publishers
+    - field.field.node.game.field_releases
+    - field.field.node.game.field_studios
     - node.type.game
   module:
     - text
@@ -32,5 +39,6 @@ hidden:
   field_images: true
   field_members: true
   field_path: true
+  field_publishers: true
   field_releases: true
   field_studios: true

--- a/config/d8/sync/core.entity_view_display.taxonomy_term.publisher.default.yml
+++ b/config/d8/sync/core.entity_view_display.taxonomy_term.publisher.default.yml
@@ -1,0 +1,30 @@
+uuid: 2c078d13-cc2d-4c8d-99fe-dd5340660a1a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.publisher.field_path
+    - taxonomy.vocabulary.publisher
+  module:
+    - fieldable_path
+    - text
+id: taxonomy_term.publisher.default
+targetEntityType: taxonomy_term
+bundle: publisher
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_path:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: fieldable_path_formatter
+    region: content
+hidden: {  }

--- a/config/d8/sync/field.field.node.game.field_publishers.yml
+++ b/config/d8/sync/field.field.node.game.field_publishers.yml
@@ -1,0 +1,29 @@
+uuid: 051ccd87-7597-4814-b1e4-e6a867be1f5e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publishers
+    - node.type.game
+    - taxonomy.vocabulary.publisher
+id: node.game.field_publishers
+field_name: field_publishers
+entity_type: node
+bundle: game
+label: Publishers
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      publisher: publisher
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/d8/sync/field.field.taxonomy_term.publisher.field_path.yml
+++ b/config/d8/sync/field.field.taxonomy_term.publisher.field_path.yml
@@ -1,0 +1,23 @@
+uuid: 90ada161-2853-4b4f-bc9a-9800ef385b89
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_path
+    - taxonomy.vocabulary.publisher
+  module:
+    - fieldable_path
+id: taxonomy_term.publisher.field_path
+field_name: field_path
+entity_type: taxonomy_term
+bundle: publisher
+label: Path
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: fieldable_path

--- a/config/d8/sync/field.storage.node.field_publishers.yml
+++ b/config/d8/sync/field.storage.node.field_publishers.yml
@@ -1,0 +1,20 @@
+uuid: 2055c282-85c6-4eb6-9598-780380d6a990
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_publishers
+field_name: field_publishers
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/d8/sync/field.storage.taxonomy_term.field_path.yml
+++ b/config/d8/sync/field.storage.taxonomy_term.field_path.yml
@@ -1,0 +1,19 @@
+uuid: 14225787-452f-40d4-aa46-2e3f8d85a5fe
+langcode: en
+status: true
+dependencies:
+  module:
+    - fieldable_path
+    - taxonomy
+id: taxonomy_term.field_path
+field_name: field_path
+entity_type: taxonomy_term
+type: fieldable_path
+settings: {  }
+module: fieldable_path
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--publisher.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--publisher.yml
@@ -1,0 +1,125 @@
+uuid: 876743b0-1217-46a3-b4b7-73561e661d68
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publisher
+id: taxonomy_term--publisher
+disabled: false
+path: taxonomy_term/publisher
+resourceType: taxonomy_term--publisher
+resourceFields:
+  tid:
+    fieldName: tid
+    publicName: tid
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_id:
+    disabled: true
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  vid:
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_created:
+    disabled: true
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: true
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: true
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: true
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+    disabled: false
+  weight:
+    disabled: true
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+  parent:
+    disabled: true
+    fieldName: parent
+    publicName: parent
+    enhancer:
+      id: ''
+  changed:
+    disabled: true
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  path:
+    disabled: true
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  field_path:
+    fieldName: field_path
+    publicName: field_path
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/d8/sync/pathauto.pattern.publishers.yml
+++ b/config/d8/sync/pathauto.pattern.publishers.yml
@@ -1,0 +1,23 @@
+uuid: 5fa28dce-3706-4266-b4fd-ad0db02c7ed5
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: publishers
+label: Publishers
+type: 'canonical_entities:taxonomy_term'
+pattern: '/publishers/[term:name]'
+selection_criteria:
+  955f12c8-58e8-4f37-8300-b07e7e0a192b:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      publisher: publisher
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: 955f12c8-58e8-4f37-8300-b07e7e0a192b
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/d8/sync/taxonomy.vocabulary.publisher.yml
+++ b/config/d8/sync/taxonomy.vocabulary.publisher.yml
@@ -1,0 +1,8 @@
+uuid: 5a598aa5-799d-46d7-99dc-b740af9b8cce
+langcode: en
+status: true
+dependencies: {  }
+name: Publisher
+vid: publisher
+description: ''
+weight: 0

--- a/web/modules/custom/gos_default_content/content/node/08952aa6-e079-496a-8efa-cbb8465d9315.json
+++ b/web/modules/custom/gos_default_content/content/node/08952aa6-e079-496a-8efa-cbb8465d9315.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/node\/12?_format=hal_json"
+            "href": "http:\/\/default\/games\/farming-simulator-19?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/node\/game"
@@ -46,7 +46,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_studios": [
             {
-                "href": "http:\/\/default\/node\/15?_format=hal_json"
+                "href": "http:\/\/default\/studio\/giants-software?_format=hal_json"
             }
         ]
     },
@@ -246,15 +246,14 @@
                     {
                         "value": "03db2f32-1f7c-4d35-a2c9-42f951ae0bd8"
                     }
-                ],
-                "date_value": "2018-11-20"
+                ]
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_studios": [
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/node\/15?_format=hal_json"
+                        "href": "http:\/\/default\/studio\/giants-software?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/node\/studio"
@@ -320,8 +319,8 @@
     ],
     "path": [
         {
-            "alias": null,
-            "pid": null,
+            "alias": "\/games\/farming-simulator-19",
+            "pid": 8,
             "langcode": "en",
             "lang": "en"
         }

--- a/web/modules/custom/gos_default_content/content/node/08952aa6-e079-496a-8efa-cbb8465d9315.json
+++ b/web/modules/custom/gos_default_content/content/node/08952aa6-e079-496a-8efa-cbb8465d9315.json
@@ -22,6 +22,14 @@
                 "href": "http:\/\/default\/taxonomy\/term\/15?_format=hal_json"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_publishers": [
+            {
+                "href": "http:\/\/default\/publishers\/astragon?_format=hal_json"
+            },
+            {
+                "href": "http:\/\/default\/publishers\/focus-home-interactive?_format=hal_json"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_releases": [
             {
                 "href": "http:\/\/default\/taxonomy\/term\/1?_format=hal_json"
@@ -123,6 +131,55 @@
                 "uuid": [
                     {
                         "value": "1bf8672b-f341-4287-8aa5-9b16c9131441"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_images": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/sites\/default\/files\/games\/2020-05\/generateImage_FemL1t.jpeg"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/file\/file"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "bfcb186d-95c3-4a47-b7f8-b076bc19cb87"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_publishers": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/publishers\/astragon?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/publisher"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "19b2fb28-468a-44ad-a03f-da4372e43539"
+                    }
+                ]
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/publishers\/focus-home-interactive?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/publisher"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "cff2f4a8-a1ac-40c0-b1c0-d5756b15c354"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/node/b7e315a4-65a1-4a34-b989-e2a5a96e1f22.json
+++ b/web/modules/custom/gos_default_content/content/node/b7e315a4-65a1-4a34-b989-e2a5a96e1f22.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/node\/15?_format=hal_json"
+            "href": "http:\/\/default\/studio\/giants-software?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/node\/studio"
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/studio\/field_members": [
             {
-                "href": "http:\/\/default\/node\/14?_format=hal_json",
+                "href": "http:\/\/default\/people\/christian-ammann?_format=hal_json",
                 "lang": "en"
             }
         ]
@@ -96,7 +96,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/node\/14?_format=hal_json"
+                        "href": "http:\/\/default\/people\/christian-ammann?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/node\/people"
@@ -164,8 +164,8 @@
     ],
     "path": [
         {
-            "alias": null,
-            "pid": null,
+            "alias": "\/studio\/giants-software",
+            "pid": 6,
             "langcode": "en",
             "lang": "en"
         }

--- a/web/modules/custom/gos_default_content/content/node/f13a9d5a-6bc0-437c-9d45-6b62d4b9f15b.json
+++ b/web/modules/custom/gos_default_content/content/node/f13a9d5a-6bc0-437c-9d45-6b62d4b9f15b.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/node\/14?_format=hal_json"
+            "href": "http:\/\/default\/people\/christian-ammann?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/node\/people"
@@ -139,8 +139,8 @@
     ],
     "path": [
         {
-            "alias": null,
-            "pid": null,
+            "alias": "\/people\/christian-ammann",
+            "pid": 5,
             "langcode": "en",
             "lang": "en"
         }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/19b2fb28-468a-44ad-a03f-da4372e43539.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/19b2fb28-468a-44ad-a03f-da4372e43539.json
@@ -1,0 +1,99 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/publishers\/astragon?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/publisher"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/publisher\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 24
+        }
+    ],
+    "uuid": [
+        {
+            "value": "19b2fb28-468a-44ad-a03f-da4372e43539"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 24
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "publisher"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-05-25T16:56:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Astragon",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/publisher\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-05-25T17:07:32+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/publishers\/astragon",
+            "pid": 10,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/publishers\/astragon"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/c16c1119-ae04-460c-9fed-e9e20d5785e7.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/c16c1119-ae04-460c-9fed-e9e20d5785e7.json
@@ -1,0 +1,99 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/publishers\/shy-robot-games?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/publisher"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/publisher\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 23
+        }
+    ],
+    "uuid": [
+        {
+            "value": "c16c1119-ae04-460c-9fed-e9e20d5785e7"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 23
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "publisher"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-05-25T16:55:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Shy Robot Games",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/publisher\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-05-25T17:07:38+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/publishers\/shy-robot-games",
+            "pid": 12,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/publishers\/shy-robot-games"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/cff2f4a8-a1ac-40c0-b1c0-d5756b15c354.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/cff2f4a8-a1ac-40c0-b1c0-d5756b15c354.json
@@ -1,0 +1,99 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/publishers\/focus-home-interactive?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/publisher"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/publisher\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 25
+        }
+    ],
+    "uuid": [
+        {
+            "value": "cff2f4a8-a1ac-40c0-b1c0-d5756b15c354"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 25
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "publisher"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-05-25T16:56:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Focus Home Interactive",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/publisher\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-05-25T17:07:34+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/publishers\/focus-home-interactive",
+            "pid": 11,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/publishers\/focus-home-interactive"
+        }
+    ]
+}

--- a/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
+++ b/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
@@ -39,9 +39,9 @@ source:
     5:
       name: location
     6:
-      name: publisher
+      name: publishers
     7:
-      name: sponsor
+      name: sponsors
     8:
       name: early_access_date
     9:
@@ -164,6 +164,32 @@ process:
             entity_type: taxonomy_term
             ignore_case: true
             access_check: false
+
+  field_publishers:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: publishers
+    -
+      plugin: explode
+      delimiter: ","
+      limit: 10
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: trim
+            source: 'value'
+          -
+            plugin: entity_generate
+            value_key: name
+            bundle_key: vid
+            bundle: publisher
+            entity_type: taxonomy_term
+            ignore_case: true
 
 destination:
   plugin: entity:node


### PR DESCRIPTION
### 💬 Describe the pull request

Publisher are now an Entity that can be attached to Games.

### 🗃️ Issues
This pull request is related to :
- close #22 

### 🚧 What has been done

- new Taxonomy Publisher
- Pathauto for Publisher
- Json:API exposition of Publisher
- 3 new default content for Publisher
- Publisher field in Games
	- Farming Simulator default game attached to Publisher
- Behat coverage of entity
- Add migrations of publishers

### 🔢 To Review
Steps to review the PR:

1. `drush cim -y && drush cr`
2. Games should be able to have Publisher(s)
3. You should be able to create Publisher as Taxonomy
3. Publishers should be migrated on `drush mim gos_games`