### PR TITLE
Add Sponsors to Games

### DIFF
--- a/behat/Features/jsonapi/sponsor.feature
+++ b/behat/Features/jsonapi/sponsor.feature
@@ -1,0 +1,30 @@
+Feature: Sponsor
+
+  Scenario: Fetching a sponsor with a wrong UUID should return a 404.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor/abcdef"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetching a sponsor by his UUID works, fetching it by his NID does not works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor/dc78845d-ba97-4fe3-889b-30680eedcd91"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor/26"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetch a sponsor using UUID should return it in the default language
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor/dc78845d-ba97-4fe3-889b-30680eedcd91"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON node "data.attributes.langcode" should be equal to "en"
+    And the JSON node "data.attributes.name" should be equal to "Kickstarter"
+    And the JSON node "data.attributes.field_path" should be equal to "/sponsors/kickstarter"
+
+  Scenario: Fetching sponsor using the path filter may return one or more results.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor?filter[field_path]=/sponsors/kickstarter"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.langcode" should be equal to "en"
+    And the JSON node "data[0].attributes.name" should be equal to "Kickstarter"
+    And the JSON node "data[0].attributes.field_path" should be equal to "/sponsors/kickstarter"

--- a/behat/Features/jsonapi/sponsors.feature
+++ b/behat/Features/jsonapi/sponsors.feature
@@ -1,0 +1,18 @@
+Feature: Sponsors
+
+  Scenario: The list of sponsor return only published ones.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data" should have 3 elements
+    And the JSON node "data[0].attributes.name" should be equal to "Kickstarter"
+    And the JSON node "data[1].attributes.name" should be equal to "Numerik Games Festival"
+    And the JSON node "data[2].attributes.name" should be equal to "Alimentarium"
+
+  Scenario: Sorting of sponsor listing works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/sponsor?sort=name"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.name" should be equal to "Alimentarium"
+    And the JSON node "data[1].attributes.name" should be equal to "Kickstarter"
+    And the JSON node "data[2].attributes.name" should be equal to "Numerik Games Festival"

--- a/config/d8/sync/core.entity_form_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_form_display.node.game.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.game.field_path
     - field.field.node.game.field_publishers
     - field.field.node.game.field_releases
+    - field.field.node.game.field_sponsors
     - field.field.node.game.field_studios
     - image.style.thumbnail
     - node.type.game
@@ -85,6 +86,7 @@ third_party_settings:
     group_meta:
       children:
         - field_genres
+        - field_sponsors
       parent_name: group_tabs
       weight: 23
       format_type: tab
@@ -160,6 +162,16 @@ content:
       match_limit: 10
     third_party_settings: {  }
     type: release_default
+    region: content
+  field_sponsors:
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_studios:
     weight: 125

--- a/config/d8/sync/core.entity_form_display.taxonomy_term.sponsor.default.yml
+++ b/config/d8/sync/core.entity_form_display.taxonomy_term.sponsor.default.yml
@@ -1,0 +1,52 @@
+uuid: 435528e4-9b7b-4dc2-a993-52b4b62ae699
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.sponsor.field_path
+    - taxonomy.vocabulary.sponsor
+  module:
+    - fieldable_path
+    - path
+    - text
+id: taxonomy_term.sponsor.default
+targetEntityType: taxonomy_term
+bundle: sponsor
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_path:
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    type: fieldable_path_widget
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/d8/sync/core.entity_view_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.game.field_path
     - field.field.node.game.field_publishers
     - field.field.node.game.field_releases
+    - field.field.node.game.field_sponsors
     - field.field.node.game.field_studios
     - node.type.game
   module:
@@ -77,6 +78,14 @@ content:
       link: true
     third_party_settings: {  }
     type: release_default
+    region: content
+  field_sponsors:
+    weight: 109
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_studios:
     weight: 102

--- a/config/d8/sync/core.entity_view_display.node.game.teaser.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.game.field_path
     - field.field.node.game.field_publishers
     - field.field.node.game.field_releases
+    - field.field.node.game.field_sponsors
     - field.field.node.game.field_studios
     - node.type.game
   module:
@@ -41,4 +42,5 @@ hidden:
   field_path: true
   field_publishers: true
   field_releases: true
+  field_sponsors: true
   field_studios: true

--- a/config/d8/sync/core.entity_view_display.taxonomy_term.sponsor.default.yml
+++ b/config/d8/sync/core.entity_view_display.taxonomy_term.sponsor.default.yml
@@ -1,0 +1,30 @@
+uuid: 68bb41e6-69ca-49db-9039-860956f26a6c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.sponsor.field_path
+    - taxonomy.vocabulary.sponsor
+  module:
+    - fieldable_path
+    - text
+id: taxonomy_term.sponsor.default
+targetEntityType: taxonomy_term
+bundle: sponsor
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_path:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: fieldable_path_formatter
+    region: content
+hidden: {  }

--- a/config/d8/sync/field.field.node.game.field_sponsors.yml
+++ b/config/d8/sync/field.field.node.game.field_sponsors.yml
@@ -1,0 +1,29 @@
+uuid: 549e25f6-7d20-4acf-a846-98281ccf0c61
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sponsors
+    - node.type.game
+    - taxonomy.vocabulary.sponsor
+id: node.game.field_sponsors
+field_name: field_sponsors
+entity_type: node
+bundle: game
+label: Sponsors
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      sponsor: sponsor
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/d8/sync/field.field.taxonomy_term.sponsor.field_path.yml
+++ b/config/d8/sync/field.field.taxonomy_term.sponsor.field_path.yml
@@ -1,0 +1,23 @@
+uuid: 3c13a772-2d58-40b2-b1ce-1849e4aa93e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_path
+    - taxonomy.vocabulary.sponsor
+  module:
+    - fieldable_path
+id: taxonomy_term.sponsor.field_path
+field_name: field_path
+entity_type: taxonomy_term
+bundle: sponsor
+label: Path
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: fieldable_path

--- a/config/d8/sync/field.storage.node.field_sponsors.yml
+++ b/config/d8/sync/field.storage.node.field_sponsors.yml
@@ -1,0 +1,20 @@
+uuid: d631402b-dc7d-451b-ba9b-9217f701be95
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_sponsors
+field_name: field_sponsors
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--sponsor.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--sponsor.yml
@@ -1,0 +1,125 @@
+uuid: 244bab1f-de4f-45e4-b485-ec833d35af0a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.sponsor
+id: taxonomy_term--sponsor
+disabled: false
+path: taxonomy_term/sponsor
+resourceType: taxonomy_term--sponsor
+resourceFields:
+  tid:
+    fieldName: tid
+    publicName: tid
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_id:
+    disabled: true
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  vid:
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_created:
+    disabled: true
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: true
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: true
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: true
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+    disabled: false
+  weight:
+    disabled: true
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+  parent:
+    disabled: true
+    fieldName: parent
+    publicName: parent
+    enhancer:
+      id: ''
+  changed:
+    disabled: true
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  path:
+    disabled: true
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  field_path:
+    fieldName: field_path
+    publicName: field_path
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/d8/sync/pathauto.pattern.sponsors.yml
+++ b/config/d8/sync/pathauto.pattern.sponsors.yml
@@ -1,0 +1,23 @@
+uuid: 728f4d2c-af61-4890-8ba0-7e485b6aec39
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: sponsors
+label: Sponsors
+type: 'canonical_entities:taxonomy_term'
+pattern: '/sponsors/[term:name]'
+selection_criteria:
+  ce168215-4faa-470f-bbfe-8116922dabd8:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      sponsor: sponsor
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: ce168215-4faa-470f-bbfe-8116922dabd8
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/d8/sync/taxonomy.vocabulary.sponsor.yml
+++ b/config/d8/sync/taxonomy.vocabulary.sponsor.yml
@@ -1,0 +1,8 @@
+uuid: 044b7ecc-c281-4825-85ad-b58ee9180803
+langcode: en
+status: true
+dependencies: {  }
+name: Sponsor
+vid: sponsor
+description: ''
+weight: 0

--- a/web/modules/custom/gos_default_content/content/node/f990d6af-d50d-4b35-a79a-72a1e12a7422.json
+++ b/web/modules/custom/gos_default_content/content/node/f990d6af-d50d-4b35-a79a-72a1e12a7422.json
@@ -26,6 +26,11 @@
             {
                 "href": "http:\/\/default\/taxonomy\/term\/10?_format=hal_json"
             }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_sponsors": [
+            {
+                "href": "http:\/\/default\/sponsors\/numerik-games-festival?_format=hal_json"
+            }
         ]
     },
     "nid": [
@@ -126,6 +131,23 @@
                 "uuid": [
                     {
                         "value": "6ea716ae-e50f-4a59-ace5-603c353ae20a"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_sponsors": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/sponsors\/numerik-games-festival?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/sponsor"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6bfe8b95-305d-4abb-924c-ec2ca6fc9895"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/08e81e70-8dba-4cc2-bc7d-b1ee13d7c9a5.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/08e81e70-8dba-4cc2-bc7d-b1ee13d7c9a5.json
@@ -1,0 +1,100 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/sponsors\/alimentarium?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/sponsor"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/sponsor\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 28
+        }
+    ],
+    "uuid": [
+        {
+            "value": "08e81e70-8dba-4cc2-bc7d-b1ee13d7c9a5"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 28
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "sponsor"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-05-26T16:39:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Alimentarium",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/sponsor\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-05-26T16:39:57+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/sponsors\/alimentarium",
+            "pid": 15,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/sponsors\/alimentarium",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/6bfe8b95-305d-4abb-924c-ec2ca6fc9895.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/6bfe8b95-305d-4abb-924c-ec2ca6fc9895.json
@@ -1,0 +1,100 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/sponsors\/numerik-games-festival?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/sponsor"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/sponsor\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 27
+        }
+    ],
+    "uuid": [
+        {
+            "value": "6bfe8b95-305d-4abb-924c-ec2ca6fc9895"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 27
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "sponsor"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-05-26T16:38:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Numerik Games Festival",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/sponsor\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-05-26T16:38:53+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/sponsors\/numerik-games-festival",
+            "pid": 14,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/sponsors\/numerik-games-festival",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/dc78845d-ba97-4fe3-889b-30680eedcd91.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/dc78845d-ba97-4fe3-889b-30680eedcd91.json
@@ -1,0 +1,100 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/sponsors\/kickstarter?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/sponsor"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/sponsor\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 26
+        }
+    ],
+    "uuid": [
+        {
+            "value": "dc78845d-ba97-4fe3-889b-30680eedcd91"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 26
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "sponsor"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-05-26T16:38:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Kickstarter",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/sponsor\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-05-26T16:38:20+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/sponsors\/kickstarter",
+            "pid": 13,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/sponsors\/kickstarter",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
+++ b/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
@@ -191,6 +191,32 @@ process:
             entity_type: taxonomy_term
             ignore_case: true
 
+  field_sponsors:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: sponsors
+    -
+      plugin: explode
+      delimiter: ","
+      limit: 10
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: trim
+            source: 'value'
+          -
+            plugin: entity_generate
+            value_key: name
+            bundle_key: vid
+            bundle: sponsor
+            entity_type: taxonomy_term
+            ignore_case: true
+
 destination:
   plugin: entity:node
   default_bundle: game


### PR DESCRIPTION
### 💬 Describe the pull request

Sponsor are now an Entity that can be attached to Games.

### 🗃️ Issues
This pull request is related to :
- close #23 

### 🚧 What has been done

- new Taxonomy Sponsor
- Pathauto for Sponsor
- Json:API exposition of Sponsor
- 3 new default content for Sponsor
- Sponsor field in Games
	- Persephone default game attached to a Sponsor
- Behat coverage of entity
- Add migrations of Sponsor

### 🔢 To Review
Steps to review the PR:

1. `drush cim -y && drush cr`
2. Games should be able to have Sponsor(s)
3. You should be able to create Sponsor as Taxonomy
3. Sponsors should be migrated on `drush mim gos_games`