### PR TITLE
Fix Travis MariaDB connection

### DIFF
--- a/behat/Features/login/login.feature
+++ b/behat/Features/login/login.feature
@@ -3,7 +3,7 @@ Feature: Login
   @api
   Scenario: Login works
     Given I am logged in as a user with the "administrator" role
-    And the url should match "/user/\d+"
+    And the url should match "/admin/content"
     And the response status code should be 200
 
   @api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal
-      MYSQL_DATABASE: drupal\_%
+      MYSQL_DATABASE: drupal_%
       MYSQL_ROOT_PASSWORD: root
     restart: always
     volumes:


### PR DESCRIPTION
# 💬 Describe the pull request

Mysql Docker base image has made a major breaking change wihtout really noticing people. They are now auto-escaping databasename containing `_`.

https://github.com/docker-library/mysql/pull/500#issuecomment-631141798

This leads our `MYSQL_DATABASE: drupal\_%` to generate bad `GRANT` by double escaping and break our builds.

To fix this, just remove our own escaping.

### 🗃️ Issues
This pull request is related to :
- close #45 