### PR TITLE
Add mandatory page to `/search/games` & init sort feature

### DIFF
--- a/behat/Features/elasticsearch/search.games.feature
+++ b/behat/Features/elasticsearch/search.games.feature
@@ -4,22 +4,38 @@ Feature: Retrieve Games items from Elasticsearch
   As a client software developer
   I need to be able to retrieve JSON encoded resources from Elasticsearch via a Proxy
 
-  Scenario: Games Resource without search parameter return all gmes.
+  Scenario: Accessing the Games Resource should require the page parameter.
     Given I send a "GET" request to "http://api.gos.test/search/games"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "message" should be equal to "Something went wrong."
+    And the JSON node "errors" should have 1 element
+    And the JSON node "errors.page" should have 1 element
+    And the JSON node "errors.page[0]" should be equal to 'This value should not be null.'
+
+  Scenario: Games Resource mandatory page parameter should be zero or positive.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=-1"
+    Then the response status code should be 500
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/json"
+    And the JSON node "message" should be equal to "Something went wrong with Elasticsearch."
+    And the JSON node "errors" should have 1 element
+#    And the JSON node "errors.page" should have 1 element
+#    And the JSON node "errors.page[0]" should be equal to 'Please provide a page number when using the "list" scheme.'
+
+  Scenario: Games Resource should respond with a paginated subset of games.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/json"
     And the JSON node "hits.total" should be equal to "4"
-    And the JSON node "hits.hits" should have 4 element
-
-  Scenario: Games Resource should respond with specific Elasticsearch structure.
-    Given I send a "GET" request to "http://api.gos.test/search/games"
-    Then the response status code should be 200
-    And the response should be in JSON
+    And the JSON node "hits.hits" should have 4 elements
 
   Scenario: The Games Resource facets/aggregations should follow a strict given structure.
-    Given I send a "GET" request to "http://api.gos.test/search/games"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 4 elements
     Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.hits.json"
+

--- a/behat/Features/elasticsearch/search.games.genres.facets.feature
+++ b/behat/Features/elasticsearch/search.games.genres.facets.feature
@@ -5,7 +5,7 @@
   I need to be able to fetch faceted Genres in a JSON encoded resources from Elasticsearch via a Proxy
 
   Scenario: The Genres facets/aggregations should follow a strict given structure.
-    Given I send a "GET" request to "http://api.gos.test/search/games"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
     Then the response status code should be 200
     And the response should be in JSON
     Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.genres.facets.json"
@@ -27,5 +27,5 @@
 
     Examples:
       | url |
-      | "http://api.gos.test/search/games" |
-      | "http://api.gos.test/search/games?genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441" |
+      | "http://api.gos.test/search/games?page=0" |
+      | "http://api.gos.test/search/games?page=0&genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441" |

--- a/behat/Features/elasticsearch/search.games.genres.feature
+++ b/behat/Features/elasticsearch/search.games.genres.feature
@@ -5,7 +5,7 @@
   I need to be able to filter by genres a JSON encoded resources from Elasticsearch via a Proxy
 
   Scenario: Games Resource should respond with filtered games when a valid genre UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 1 element
@@ -15,7 +15,7 @@
       | hits.hits[0]._source.id | 12 |
 
   Scenario: Games Resource should respond with filtered games when multiple valid genres UUID are given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441&genresUuid[]=55d245b5-c9cc-43e5-8400-c44ef4f2d8ad"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441&genresUuid[]=55d245b5-c9cc-43e5-8400-c44ef4f2d8ad"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 2 elements
@@ -26,7 +26,7 @@
       | hits.hits[1]._source.id | 17 |
 
   Scenario: Games Resource should respond with an error when a non-valid genre UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?genresUuid[]=test"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=test"
     Then the response status code should be 400
     And the response should be in JSON
     And the JSON node "errors.genres" should exist

--- a/behat/Features/elasticsearch/search.games.platforms.facets.feature
+++ b/behat/Features/elasticsearch/search.games.platforms.facets.feature
@@ -5,13 +5,13 @@
   I need to be able to fetch faceted Platforms in a JSON encoded resources from Elasticsearch via a Proxy
 
   Scenario: The Platforms facets/aggregations should follow a strict given structure.
-    Given I send a "GET" request to "http://api.gos.test/search/games"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
     Then the response status code should be 200
     And the response should be in JSON
     Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.platforms.facets.json"
 
   Scenario: The Platforms facets/aggregations should use the same filter as the global query - without itself as filter.
-    Given I send a "GET" request to "http://api.gos.test/search/games?platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
     Then the response status code should be 200
     And the response should be in JSON
 
@@ -46,5 +46,5 @@
 
     Examples:
       | url |
-      | "http://api.gos.test/search/games" |
-      | "http://api.gos.test/search/games?platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7" |
+      | "http://api.gos.test/search/games?page=0" |
+      | "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7" |

--- a/behat/Features/elasticsearch/search.games.platforms.feature
+++ b/behat/Features/elasticsearch/search.games.platforms.feature
@@ -5,7 +5,7 @@
   I need to be able to filter by platforms a JSON encoded resources from Elasticsearch via a Proxy
 
   Scenario: Games Resource should respond with filtered games when a valid platform UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 2 element
@@ -16,7 +16,7 @@
       | hits.hits[1]._source.id | 12 |
 
   Scenario: Games Resource should respond with filtered games when multiple valid platforms UUID are given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7&platformsUuid[]=6ea716ae-e50f-4a59-ace5-603c353ae20a"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7&platformsUuid[]=6ea716ae-e50f-4a59-ace5-603c353ae20a"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 3 elements
@@ -29,7 +29,7 @@
       | hits.hits[2]._source.id | 17 |
 
   Scenario: Games Resource should respond with an error when a non-valid platform UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?platformsUuid[]=test"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=test"
     Then the response status code should be 400
     And the response should be in JSON
     And the JSON node "errors.platforms" should exist

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -20,6 +20,15 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 class ElasticGamesResourceValidator extends BaseValidator {
 
   /**
+   * List of sortable properties.
+   *
+   * @var array
+   */
+  private const SORTABLE = [
+    '_score',
+  ];
+
+  /**
    * The game Genres to filter by.
    *
    * This field uses the custom validation ::validateGenres.
@@ -36,6 +45,17 @@ class ElasticGamesResourceValidator extends BaseValidator {
   private $genresUuid;
 
   /**
+   * The page to fetch.
+   *
+   * The page parameter is mandatory to avoid search overload.
+   *
+   * @var int
+   *
+   * @Assert\NotNull
+   */
+  private $page;
+
+  /**
    * The game Platforms to filter by.
    *
    * This field uses the custom validation ::validatePlatforms.
@@ -50,6 +70,15 @@ class ElasticGamesResourceValidator extends BaseValidator {
    * @var string[]
    */
   private $platformsUuid;
+
+  /**
+   * Sort property with direction as key.
+   *
+   * This property uses the custom validation ::validateSort.
+   *
+   * @var array
+   */
+  private $sort = [];
 
   /**
    * Get the game Genres to filter by.
@@ -69,6 +98,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function getGenresUuid(): ?array {
     return $this->genresUuid;
+  }
+
+  /**
+   * Get page.
+   *
+   * @return int|null
+   *   The value.
+   */
+  public function getPage(): ?int {
+    return (int) $this->page;
   }
 
   /**
@@ -92,6 +131,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
+   * Get the sort information.
+   *
+   * @return array
+   *   Sort property with a direction (asc/desc) as key.
+   */
+  public function getSort(): array {
+    return $this->sort;
+  }
+
+  /**
    * Set the Genres to filter by.
    *
    * @param \Drupal\taxonomy\TermInterface[] $genres
@@ -112,6 +161,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
+   * Set page name.
+   *
+   * @param int $page
+   *   The integer page to set.
+   */
+  public function setPage($page): void {
+    $this->page = $page;
+  }
+
+  /**
    * Set the Platforms to filter by.
    *
    * @param \Drupal\taxonomy\TermInterface[] $platforms
@@ -129,6 +188,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function setPlatformsUuid(array $platforms_uuid): void {
     $this->platformsUuid = $platforms_uuid;
+  }
+
+  /**
+   * Set the sort information.
+   *
+   * @param array $sort
+   *   Sort information.
+   */
+  public function setSort(array $sort): void {
+    $this->sort = $sort;
   }
 
   /**
@@ -171,6 +240,38 @@ class ElasticGamesResourceValidator extends BaseValidator {
     if ($this->platformsUuid && !$this->platforms) {
       $context->buildViolation(sprintf('At least one given Platform(s) UUID has not been found.'))
         ->atPath('platforms')
+        ->addViolation();
+    }
+  }
+
+  /**
+   * Validates the sort parameter.
+   *
+   * The sort parameter only works for the list scheme.
+   *
+   * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
+   *   The validation execution context.
+   * @param string $payload
+   *   The Payload.
+   *
+   * @Assert\Callback
+   */
+  public function validateSort(ExecutionContextInterface $context, $payload): void {
+    if (!$this->sort) {
+      $this->sort = [];
+
+      return;
+    }
+
+    if (!\array_key_exists('asc', $this->sort) && !\array_key_exists('desc', $this->sort)) {
+      $context->buildViolation(sprintf('Provided direction "%s" is not supported. Please use "asc" or "desc".', key($this->sort)))
+        ->atPath('sort')
+        ->addViolation();
+    }
+
+    if (!\in_array($this->sort[key($this->sort)], $this::SORTABLE, TRUE)) {
+      $context->buildViolation(sprintf('Provided property "%s" is not sortable.', $this->sort[key($this->sort)]))
+        ->atPath('sort')
         ->addViolation();
     }
   }

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -83,14 +83,20 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The property you want the results to be sorted by and ordered ASC. Available : _score."
+            "enum": [
+              "_score"
+            ],
+            "description": "The property you want the results to be sorted by and ordered ASC."
           },
           {
             "name": "sort[desc]",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The property you want the results to be sorted by and ordered DESC. Available : _score."
+            "enum": [
+              "_score"
+            ],
+            "description": "The property you want the results to be sorted by and ordered DESC."
           },
           {
             "name": "genresUuid[]",

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -71,6 +71,28 @@
         ],
         "parameters": [
           {
+            "name": "page",
+            "in": "query",
+            "required": true,
+            "type": "integer",
+            "description": "The page to fetch.",
+            "default": 0
+          },
+          {
+            "name": "sort[asc]",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The property you want the results to be sorted by and ordered ASC. Available : _score."
+          },
+          {
+            "name": "sort[desc]",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The property you want the results to be sorted by and ordered DESC. Available : _score."
+          },
+          {
             "name": "genresUuid[]",
             "in": "query",
             "required": false,


### PR DESCRIPTION
### 💬 Describe the pull request
A clear and concise description of what the pull request is about.

### 🗃️ Issues
This pull request is related to :
- close #7 
- init #4 

### 🌩 API Swagger documentation

New `page` mandatory argument to `/search/games`.
This new argument must be an Integer zeroOrPositive.

Usage: `http://api.gos.test/search/games?page=0`

New `sort` capability that only suppoprt - for now - `_score`.
Usage: `http://api.gos.test/search/games?page=0&sort[desc]=_score`
Usage: `http://api.gos.test/search/games?page=0&sort[asc]=_score`
