### PR TITLE
Slugify Genres & Platforms

### DIFF
--- a/behat/Features/elasticsearch/search.games.genres.facets.feature
+++ b/behat/Features/elasticsearch/search.games.genres.facets.feature
@@ -16,40 +16,40 @@
     And the response should be in JSON
     And the JSON node "aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets" should have 4 elements
     And the JSON nodes should be equal to:
-      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].key | Adventure |
+      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].key | adventure |
       | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].key | Platformer |
+      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].key | platformer |
       | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].key | Puzzle |
+      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].key | puzzle |
       | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].key | Simulation |
+      | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].key | simulation |
       | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].doc_count | 1 |
     Examples:
       | url |
       | "http://api.gos.test/search/games?page=0" |
-      | "http://api.gos.test/search/games?page=0&genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441" |
+      | "http://api.gos.test/search/games?page=0&genres[]=simulation" |
 
 
     Scenario: The Genres facets/aggregations should be affected by filtered Stores and/or Platforms.
-      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=6ea716ae-e50f-4a59-ace5-603c353ae20a"
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=ios"
     And the JSON node "aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets" should have 4 elements
       And the JSON nodes should be equal to:
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].key | Puzzle |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].key | puzzle |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].key | Adventure |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].key | adventure |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].key | Platformer |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].key | platformer |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].key | Simulation |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].key | simulation |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].doc_count | 0 |
       Given I send a "GET" request to "http://api.gos.test/search/games?page=0&stores[]=steam"
     And the JSON node "aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets" should have 4 elements
       And the JSON nodes should be equal to:
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].key | Simulation |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].key | simulation |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[0].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].key | Adventure |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].key | adventure |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[1].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].key | Platformer |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].key | platformer |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[2].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].key | Puzzle |
+        | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].key | puzzle |
         | aggregations.aggs_all.all_filtered_genres.all_nested_genres.genres_name_keyword.buckets[3].doc_count | 0 |

--- a/behat/Features/elasticsearch/search.games.genres.feature
+++ b/behat/Features/elasticsearch/search.games.genres.feature
@@ -4,8 +4,8 @@
   As a client software developer
   I need to be able to filter by genres a JSON encoded resources from Elasticsearch via a Proxy
 
-  Scenario: Games Resource should respond with filtered games when a valid genre UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441"
+  Scenario: Games Resource should respond with filtered games when a valid genre slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genres[]=simulation"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 1 element
@@ -14,8 +14,8 @@
       | hits.hits[0]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
       | hits.hits[0]._source.id | 12 |
 
-  Scenario: Games Resource should respond with filtered games when multiple valid genres UUID are given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=1bf8672b-f341-4287-8aa5-9b16c9131441&genresUuid[]=55d245b5-c9cc-43e5-8400-c44ef4f2d8ad"
+  Scenario: Games Resource should respond with filtered games when multiple valid genres slugs are given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genres[]=simulation&genres[]=puzzle"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 2 elements
@@ -25,10 +25,10 @@
       | hits.hits[1]._source.uuid | f990d6af-d50d-4b35-a79a-72a1e12a7422 |
       | hits.hits[1]._source.id | 17 |
 
-  Scenario: Games Resource should respond with an error when a non-valid genre UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=test"
+  Scenario: Games Resource should respond with an error when a non-valid genre slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genres[]=test"
     Then the response status code should be 400
     And the response should be in JSON
     And the JSON node "errors.genres" should exist
     And the JSON node "errors.genres" should have 1 element
-    And the JSON node "errors.genres[0]" should be equal to "At least one given Genre(s) UUID has not been found."
+    And the JSON node "errors.genres[0]" should be equal to "At least one given Genre(s) has not been found."

--- a/behat/Features/elasticsearch/search.games.platforms.facets.feature
+++ b/behat/Features/elasticsearch/search.games.platforms.facets.feature
@@ -11,7 +11,7 @@
     Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.platforms.facets.json"
 
   Scenario: The Platforms facets/aggregations should use the same filter as the global query - without itself as filter.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=pc"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON nodes should be equal to:
@@ -24,63 +24,63 @@
     And the response should be in JSON
     And the JSON node "aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets" should have 8 elements
     And the JSON nodes should be equal to:
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].key | Mac |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].key | ios |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].doc_count | 2 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].key | PC |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].key | mac |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].doc_count | 2 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].key | iOS |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].key | pc |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].doc_count | 2 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].key | Android |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].key | android |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].key | Nintendo 3DS |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].key | nintendo_3ds |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].key | PlayStation 4 |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].key | playstation_4 |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].key | PlayStation Vita |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].key | playstation_vita |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].doc_count | 1 |
-      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].key | Xbox One |
+      | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].key | xbox_one |
       | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].doc_count | 1 |
     Examples:
       | url |
       | "http://api.gos.test/search/games?page=0" |
-      | "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7" |
+      | "http://api.gos.test/search/games?page=0&platforms[]=pc" |
 
     Scenario: The Platforms facets/aggregations should be affected by filtered Stores and/or Genres.
-      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=55d245b5-c9cc-43e5-8400-c44ef4f2d8ad"
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genres[]=puzzle"
       And the JSON node "aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets" should have 8 elements
       And the JSON nodes should be equal to:
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].key | iOS |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].key | ios |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].key | Android |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].key | android |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].key | Mac |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].key | mac |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].key | Nintendo 3DS |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].key | nintendo_3ds |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].key | PC |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].key | pc |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].key | PlayStation 4 |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].key | playstation_4 |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].key | PlayStation Vita |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].key | playstation_vita |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].key | Xbox One |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].key | xbox_one |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].doc_count | 0 |
       Given I send a "GET" request to "http://api.gos.test/search/games?page=0&stores[]=steam"
       And the JSON node "aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets" should have 8 elements
       And the JSON nodes should be equal to:
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].key | Mac |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].key | mac |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[0].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].key | PC |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].key | pc |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[1].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].key | PlayStation 4 |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].key | playstation_4 |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[2].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].key | Xbox One |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].key | xbox_one |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[3].doc_count | 1 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].key | Android |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].key | android |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[4].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].key | Nintendo 3DS |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].key | ios |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[5].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].key | PlayStation Vita |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].key | nintendo_3ds |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[6].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].key | iOS |
+        | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].key | playstation_vita |
         | aggregations.aggs_all.all_filtered_platforms.all_nested_platforms.platforms_name_keyword.buckets[7].doc_count | 0 |

--- a/behat/Features/elasticsearch/search.games.platforms.feature
+++ b/behat/Features/elasticsearch/search.games.platforms.feature
@@ -4,8 +4,8 @@
   As a client software developer
   I need to be able to filter by platforms a JSON encoded resources from Elasticsearch via a Proxy
 
-  Scenario: Games Resource should respond with filtered games when a valid platform UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
+  Scenario: Games Resource should respond with filtered games when a valid platform slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=pc"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 2 element
@@ -15,8 +15,8 @@
       | hits.hits[1]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
       | hits.hits[1]._source.id | 12 |
 
-  Scenario: Games Resource should respond with filtered games when multiple valid platforms UUID are given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7&platformsUuid[]=6ea716ae-e50f-4a59-ace5-603c353ae20a"
+  Scenario: Games Resource should respond with filtered games when multiple valid platforms slugs are given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=pc&platforms[]=ios"
     Then the response status code should be 200
     And the response should be in JSON
     And the JSON node "hits.hits" should have 3 elements
@@ -28,10 +28,10 @@
       | hits.hits[2]._source.uuid | f990d6af-d50d-4b35-a79a-72a1e12a7422 |
       | hits.hits[2]._source.id | 17 |
 
-  Scenario: Games Resource should respond with an error when a non-valid platform UUID is given.
-    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=test"
+  Scenario: Games Resource should respond with an error when a non-valid platform slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=test"
     Then the response status code should be 400
     And the response should be in JSON
     And the JSON node "errors.platforms" should exist
     And the JSON node "errors.platforms" should have 1 element
-    And the JSON node "errors.platforms[0]" should be equal to "At least one given Platform(s) UUID has not been found."
+    And the JSON node "errors.platforms[0]" should be equal to "At least one given Platform(s) has not been found."

--- a/behat/Features/elasticsearch/search.games.stores.facets.feature
+++ b/behat/Features/elasticsearch/search.games.stores.facets.feature
@@ -37,7 +37,7 @@
       | "http://api.gos.test/search/games?page=0&stores[]=apple_store" |
 
     Scenario: The Stores facets/aggregations should be affected by filtered Platforms and/or Genres.
-      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platformsUuid[]=304a43fe-3c4d-4587-93e6-a84959d39bf7"
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=pc"
       And the JSON node "aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets" should have 4 elements
       And the JSON nodes should be equal to:
         | aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets[0].key | custom |
@@ -48,7 +48,7 @@
         | aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets[2].doc_count | 0 |
         | aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets[3].key | google_play_store |
         | aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets[3].doc_count | 0 |
-      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genresUuid[]=55d245b5-c9cc-43e5-8400-c44ef4f2d8ad"
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&genres[]=puzzle"
       And the JSON node "aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets" should have 4 elements
       And the JSON nodes should be equal to:
         | aggregations.aggs_all.all_filtered_stores.all_nested_stores.stores_name_keyword.buckets[0].key | apple_store |

--- a/config/d8/sync/core.entity_form_display.taxonomy_term.genre.default.yml
+++ b/config/d8/sync/core.entity_form_display.taxonomy_term.genre.default.yml
@@ -1,0 +1,45 @@
+uuid: 29a5dc5c-6b5e-4985-8ece-d28711714420
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.genre.field_slug
+    - taxonomy.vocabulary.genre
+  module:
+    - path
+id: taxonomy_term.genre.default
+targetEntityType: taxonomy_term
+bundle: genre
+mode: default
+content:
+  field_slug:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/d8/sync/core.entity_form_display.taxonomy_term.platform.default.yml
+++ b/config/d8/sync/core.entity_form_display.taxonomy_term.platform.default.yml
@@ -1,0 +1,45 @@
+uuid: 29bec3c4-aa2c-44bd-9a7f-9a17507af4f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.platform.field_slug
+    - taxonomy.vocabulary.platform
+  module:
+    - path
+id: taxonomy_term.platform.default
+targetEntityType: taxonomy_term
+bundle: platform
+mode: default
+content:
+  field_slug:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/d8/sync/core.entity_view_display.taxonomy_term.genre.default.yml
+++ b/config/d8/sync/core.entity_view_display.taxonomy_term.genre.default.yml
@@ -1,0 +1,30 @@
+uuid: 8112104e-7719-4c59-8d14-22fbb6350e66
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.genre.field_slug
+    - taxonomy.vocabulary.genre
+  module:
+    - text
+id: taxonomy_term.genre.default
+targetEntityType: taxonomy_term
+bundle: genre
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_slug:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/config/d8/sync/core.entity_view_display.taxonomy_term.platform.default.yml
+++ b/config/d8/sync/core.entity_view_display.taxonomy_term.platform.default.yml
@@ -1,0 +1,30 @@
+uuid: e3111ca2-4c1e-4373-a207-624deae6617a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.platform.field_slug
+    - taxonomy.vocabulary.platform
+  module:
+    - text
+id: taxonomy_term.platform.default
+targetEntityType: taxonomy_term
+bundle: platform
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_slug:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/config/d8/sync/field.field.taxonomy_term.genre.field_slug.yml
+++ b/config/d8/sync/field.field.taxonomy_term.genre.field_slug.yml
@@ -1,0 +1,19 @@
+uuid: 3c3e6dc2-a93e-4c4e-9fc6-e516ce70999b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_slug
+    - taxonomy.vocabulary.genre
+id: taxonomy_term.genre.field_slug
+field_name: field_slug
+entity_type: taxonomy_term
+bundle: genre
+label: Slug
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/d8/sync/field.field.taxonomy_term.platform.field_slug.yml
+++ b/config/d8/sync/field.field.taxonomy_term.platform.field_slug.yml
@@ -1,0 +1,19 @@
+uuid: d4f52e89-d14c-423f-a739-584154b816f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_slug
+    - taxonomy.vocabulary.platform
+id: taxonomy_term.platform.field_slug
+field_name: field_slug
+entity_type: taxonomy_term
+bundle: platform
+label: Slug
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/d8/sync/field.storage.taxonomy_term.field_slug.yml
+++ b/config/d8/sync/field.storage.taxonomy_term.field_slug.yml
@@ -1,0 +1,21 @@
+uuid: 44b8356a-8431-4b16-a3fa-56edce809bd3
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_slug
+field_name: field_slug
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--genre.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--genre.yml
@@ -117,3 +117,9 @@ resourceFields:
     publicName: path
     enhancer:
       id: ''
+  field_slug:
+    fieldName: field_slug
+    publicName: slug
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--platform.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--platform.yml
@@ -117,3 +117,9 @@ resourceFields:
     publicName: path
     enhancer:
       id: ''
+  field_slug:
+    fieldName: field_slug
+    publicName: slug
+    enhancer:
+      id: ''
+    disabled: false

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
@@ -133,14 +133,7 @@ class GameNodeIndex extends NodeIndexBase {
                   'type' => 'date',
                   'format' => 'yyyy-MM-dd',
                 ],
-                'platform' => [
-                  'type' => 'text',
-                  'analyzer' => 'synonym_platform_analyzer',
-                ],
-                'platform_keyword' => [
-                  'type' => 'keyword',
-                ],
-                'platform_uuid' => [
+                'platform_slug' => [
                   'type' => 'keyword',
                 ],
               ],
@@ -166,18 +159,7 @@ class GameNodeIndex extends NodeIndexBase {
               'dynamic' => FALSE,
               'type' => 'nested',
               'properties' => [
-                'name' => [
-                  'type' => 'text',
-                  'fields' => [
-                    'raw' => [
-                      'type' => 'keyword',
-                    ],
-                  ],
-                ],
-                'name_keyword' => [
-                  'type' => 'keyword',
-                ],
-                'uuid' => [
+                'slug' => [
                   'type' => 'keyword',
                 ],
               ],
@@ -186,15 +168,7 @@ class GameNodeIndex extends NodeIndexBase {
               'dynamic' => FALSE,
               'type' => 'nested',
               'properties' => [
-                'name' => [
-                  'type' => 'text',
-                  'fields' => [
-                    'raw' => [
-                      'type' => 'keyword',
-                    ],
-                  ],
-                ],
-                'name_keyword' => [
+                'slug' => [
                   'type' => 'keyword',
                 ],
                 'link' => [

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/Normalizer/GameNormalizer.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/Normalizer/GameNormalizer.php
@@ -46,9 +46,7 @@ class GameNormalizer extends ContentEntityNormalizer {
       foreach ($object->field_releases as $release) {
         $releases[] = [
           'date' => isset($release->date_value) ? $release->date_value : NULL,
-          'platform' => isset($release->entity) ? $release->entity->getName() : NULL,
-          'platform_keyword' => isset($release->entity) ? $release->entity->getName() : NULL,
-          'platform_uuid' => isset($release->entity) ? $release->entity->get('uuid')->value : NULL,
+          'platform_slug' => isset($release->entity) ? $release->entity->get('field_slug')->value : NULL,
         ];
       }
 
@@ -75,9 +73,7 @@ class GameNormalizer extends ContentEntityNormalizer {
 
       foreach ($object->field_genres as $genre) {
         $genres[] = [
-          'name' => $genre->entity->name->value,
-          'name_keyword' => $genre->entity->name->value,
-          'uuid' => $genre->entity->get('uuid')->value,
+          'slug' => $genre->entity->get('field_slug')->value,
         ];
       }
 
@@ -90,8 +86,7 @@ class GameNormalizer extends ContentEntityNormalizer {
 
       foreach ($object->field_stores as $store) {
         $genres[] = [
-          'name' => $store->store,
-          'name_keyword' => $store->store,
+          'slug' => $store->store,
           'link' => $store->link,
         ];
       }

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -70,13 +70,6 @@ class ElasticGamesResourceValidator extends BaseValidator {
   private $platforms;
 
   /**
-   * The Platforms Uuid.
-   *
-   * @var string[]
-   */
-  private $platformsSlugs;
-
-  /**
    * Sort property with direction as key.
    *
    * This property uses the custom validation ::validateSort.

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -32,6 +32,15 @@ class ElasticGamesResourceValidator extends BaseValidator {
   ];
 
   /**
+   * All raw element.
+   *
+   * This field may used in custom validators.
+   *
+   * @var array
+   */
+  protected $raw;
+
+  /**
    * The game Genres to filter by.
    *
    * This field uses the custom validation ::validateGenres.
@@ -39,13 +48,6 @@ class ElasticGamesResourceValidator extends BaseValidator {
    * @var \Drupal\taxonomy\TermInterface[]|null
    */
   private $genres;
-
-  /**
-   * The Genres Uuid.
-   *
-   * @var string[]
-   */
-  private $genresUuid;
 
   /**
    * The page to fetch.
@@ -72,7 +74,7 @@ class ElasticGamesResourceValidator extends BaseValidator {
    *
    * @var string[]
    */
-  private $platformsUuid;
+  private $platformsSlugs;
 
   /**
    * Sort property with direction as key.
@@ -103,16 +105,6 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
-   * Get the game Genres UUID to filter by.
-   *
-   * @return string[]|null
-   *   Genres uuid.
-   */
-  public function getGenresUuid(): ?array {
-    return $this->genresUuid;
-  }
-
-  /**
    * Get page.
    *
    * @return int|null
@@ -133,13 +125,13 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
-   * Get the game Platforms UUID to filter by.
+   * Get the raw values.
    *
-   * @return string[]|null
-   *   Platforms uuid.
+   * @return array
+   *   The raw values.
    */
-  public function getPlatformsUuid(): ?array {
-    return $this->platformsUuid;
+  public function getRaw(): array {
+    return $this->raw;
   }
 
   /**
@@ -173,16 +165,6 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
-   * Set the Genres Uuid.
-   *
-   * @param string[] $genres_uuid
-   *   Genres Uuid.
-   */
-  public function setGenresUuid(array $genres_uuid): void {
-    $this->genresUuid = $genres_uuid;
-  }
-
-  /**
    * Set page name.
    *
    * @param int $page
@@ -203,13 +185,13 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
-   * Set the Platforms Uuid.
+   * Set raw values.
    *
-   * @param string[] $platforms_uuid
-   *   Platforms Uuid.
+   * @param array $raw
+   *   The raw values .
    */
-  public function setPlatformsUuid(array $platforms_uuid): void {
-    $this->platformsUuid = $platforms_uuid;
+  public function setRaw(array $raw): void {
+    $this->raw = $raw;
   }
 
   /**
@@ -245,10 +227,8 @@ class ElasticGamesResourceValidator extends BaseValidator {
    * @Assert\Callback
    */
   public function validateGenres(ExecutionContextInterface $context, $payload): void {
-    // @TODO Improve error detection by checking both array dimensions and give
-    // proper UUID feedback error.
-    if ($this->genresUuid && !$this->genres) {
-      $context->buildViolation(sprintf('At least one given Genre(s) UUID has not been found.'))
+    if (isset($this->raw['genres']) && !$this->genres) {
+      $context->buildViolation(sprintf('At least one given Genre(s) has not been found.'))
         ->atPath('genres')
         ->addViolation();
     }
@@ -267,10 +247,8 @@ class ElasticGamesResourceValidator extends BaseValidator {
    * @Assert\Callback
    */
   public function validatePlatforms(ExecutionContextInterface $context, $payload): void {
-    // @TODO Improve error detection by checking both array dimensions and give
-    // proper UUID feedback error.
-    if ($this->platformsUuid && !$this->platforms) {
-      $context->buildViolation(sprintf('At least one given Platform(s) UUID has not been found.'))
+    if (isset($this->raw['platforms']) && !$this->platforms) {
+      $context->buildViolation(sprintf('At least one given Platform(s) has not been found.'))
         ->atPath('platforms')
         ->addViolation();
     }

--- a/web/modules/custom/gos_migrate/gos_migrate.info.yml
+++ b/web/modules/custom/gos_migrate/gos_migrate.info.yml
@@ -1,4 +1,4 @@
-name: MSF Migration
+name: Games of Switzerland Elasticsearch Migration
 type: module
 description: Module used to handle migrations from an exported CSV of Google Spreadsheet
 package: Games of Switzerland

--- a/web/modules/custom/gos_site/gos_site.module
+++ b/web/modules/custom/gos_site/gos_site.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -19,4 +20,22 @@ function gos_site_form_user_login_form_alter(array &$form, FormStateInterface $f
  */
 function _gos_site_user_login_form_submit(array $form, FormStateInterface $form_state) {
   $form_state->setRedirect('system.admin_content', [], []);
+}
+
+/**
+ * For Taxonomy Terms with Slug field, when empty Slug generate value from Name.
+ *
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function gos_site_taxonomy_term_insert(TermInterface $entity) {
+  // Don't generate for entity without Slug field or non-empty Slug field.
+  if (!$entity->hasField('field_slug') || !$entity->field_slug->isEmpty()) {
+    return;
+  }
+
+  // Replace w/ underscore anything that isn't A-Z, numbers, dashes, or underscores.
+  $slug = mb_strtolower(trim(preg_replace('/[^a-zA-Z0-9-]+/', '_', $entity->getName()), '_'));
+
+  $entity->get('field_slug')->setValue($slug);
+  $entity->save();
 }

--- a/web/modules/custom/gos_site/gos_site.module
+++ b/web/modules/custom/gos_site/gos_site.module
@@ -33,7 +33,7 @@ function gos_site_taxonomy_term_insert(TermInterface $entity) {
     return;
   }
 
-  // Replace w/ underscore anything that isn't A-Z, numbers, dashes, or underscores.
+  // Replace w/ underscore anything that isn't A-Z, numbers, or dashes.
   $slug = mb_strtolower(trim(preg_replace('/[^a-zA-Z0-9-]+/', '_', $entity->getName()), '_'));
 
   $entity->get('field_slug')->setValue($slug);

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -105,27 +105,39 @@
             "description": "The property you want the results to be sorted by and ordered DESC."
           },
           {
-            "name": "genresUuid[]",
+            "name": "genres[]",
             "in": "query",
             "required": false,
             "type": "array",
-            "description": "Collection of genres UUID. Items are matched using an Inner OR condition.",
+            "description": "Collection of genres slug. Items are matched using an Inner OR condition.",
             "items": {
               "type": "string"
             },
-            "example": "1bf8672b-f341-4287-8aa5-9b16c9131441",
+            "example": "simulation",
             "uniqueItems": true
           },
           {
-            "name": "platformsUuid[]",
+            "name": "stores[]",
             "in": "query",
             "required": false,
             "type": "array",
-            "description": "Collection of platforms UUID. Items are matched using an Inner OR condition.",
+            "description": "Collection of stores slug. Items are matched using an Inner OR condition.",
             "items": {
               "type": "string"
             },
-            "example": "304a43fe-3c4d-4587-93e6-a84959d39bf7",
+            "example": "steam",
+            "uniqueItems": true
+          },
+          {
+            "name": "platforms[]",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "description": "Collection of platforms slug. Items are matched using an Inner OR condition.",
+            "items": {
+              "type": "string"
+            },
+            "example": "ps4",
             "uniqueItems": true
           }
         ],


### PR DESCRIPTION
### 💬 Describe the pull request

- Remove usage of UUIDs for filtering `search/games` (genres & platforms) and use a slugified value instead.
- Automatically generate a slug for those entity on insert (if field empty)

### 🗃️ Issues
This pull request is related to :
- close #52
- close #53 

### 🔢 To Review

Now instead of using UUID for Genres & Platforms, you should use a slug.
Remove many uuid from ES as not needed anymore.