### PR TITLE
Add locations to games

### DIFF
--- a/behat/Features/elasticsearch/search.games.locations.facets.feature
+++ b/behat/Features/elasticsearch/search.games.locations.facets.feature
@@ -1,0 +1,42 @@
+@elasticsearch
+  Feature: Retrieve Games Locations facets from Elasticsearch
+  In order to filter the Games Search API
+  As a client software developer
+  I need to be able to fetch faceted Locations in a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: The Locations facets/aggregations should follow a strict given structure.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.locations.facets.json"
+
+  Scenario Outline: The Locations facets/aggregations should use the same filter as the global query - without itself as filter.
+    Given I send a "GET" request to <url>
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 2 elements
+    And the JSON nodes should be equal to:
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | fribourg |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | zurich |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 1 |
+    Examples:
+      | url |
+      | "http://api.gos.test/search/games?page=0" |
+      | "http://api.gos.test/search/games?page=0&locations[]=zurich" |
+
+    Scenario: The Locations facets/aggregations should be affected by filtered Stores and/or Platforms.
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=ios"
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 2 elements
+      And the JSON nodes should be equal to:
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | fribourg |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 0 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | zurich |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 0 |
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&stores[]=steam"
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 2 elements
+      And the JSON nodes should be equal to:
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | zurich |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | fribourg |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 0 |

--- a/behat/Features/elasticsearch/search.games.locations.feature
+++ b/behat/Features/elasticsearch/search.games.locations.feature
@@ -1,0 +1,31 @@
+@elasticsearch
+  Feature: Retrieve Games items from Elasticsearch
+  In order to use a Games Search API
+  As a client software developer
+  I need to be able to filter by locations a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: Games Resource should respond with filtered games when a valid genre slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&locations[]=zurich"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 1 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
+
+  Scenario: Games Resource should respond with filtered games when multiple valid locations slugs are given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&locations[]=zurich&locations[]=fribourg"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 2 elements
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
+      | hits.hits[1]._source.uuid | 9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd |
+
+  Scenario: Games Resource should respond with an error when a non-valid genre slug is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&locations[]=test"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the JSON node "errors.locations" should exist
+    And the JSON node "errors.locations" should have 1 element
+    And the JSON node "errors.locations[0]" should be equal to "At least one given Location(s) has not been found."

--- a/behat/Features/jsonapi/location.feature
+++ b/behat/Features/jsonapi/location.feature
@@ -1,0 +1,30 @@
+Feature: Location
+
+  Scenario: Fetching a location with a wrong UUID should return a 404.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location/abcdef"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetching a location by his UUID works, fetching it by his NID does not works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location/e181208c-fd4d-47bc-9767-4965d670bc2f"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location/34"
+    Then the response status code should be 404
+    And the response should be in JSON
+
+  Scenario: Fetch a location using UUID should return it in the default language
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location/e181208c-fd4d-47bc-9767-4965d670bc2f"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON node "data.attributes.langcode" should be equal to "en"
+    And the JSON node "data.attributes.name" should be equal to "Zürich"
+    And the JSON node "data.attributes.slug" should be equal to "zurich"
+
+  Scenario: Fetching location using the slug filter may return one or more results.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location?filter[slug]=zurich"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.langcode" should be equal to "en"
+    And the JSON node "data[0].attributes.name" should be equal to "Zürich"
+    And the JSON node "data[0].attributes.slug" should be equal to "zurich"

--- a/behat/Features/jsonapi/locations.feature
+++ b/behat/Features/jsonapi/locations.feature
@@ -1,0 +1,18 @@
+Feature: Locations
+
+  Scenario: The list of location return only published ones.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data" should have 3 elements
+    And the JSON node "data[0].attributes.name" should be equal to "Geneva"
+    And the JSON node "data[1].attributes.name" should be equal to "Zürich"
+    And the JSON node "data[2].attributes.name" should be equal to "Fribourg"
+
+  Scenario: Sorting of location listing works.
+    Given I am on "/G70VW4Y9sP/jsonapi/taxonomy_term/location?sort=name"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "data[0].attributes.name" should be equal to "Fribourg"
+    And the JSON node "data[1].attributes.name" should be equal to "Geneva"
+    And the JSON node "data[2].attributes.name" should be equal to "Zürich"

--- a/behat/Fixtures/elasticsearch/schemaref.search.games.locations.facets.json
+++ b/behat/Fixtures/elasticsearch/schemaref.search.games.locations.facets.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "title": "The root schema",
+  "required": [
+    "aggregations"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "aggregations": {
+      "$id": "#/properties/aggregations",
+      "type": "object",
+      "title": "The aggregations schema",
+      "required": [
+        "aggs_all"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "aggs_all": {
+          "$id": "#/properties/aggregations/properties/aggs_all",
+          "type": "object",
+          "title": "The aggs_all schema",
+          "required": [
+            "all_filtered_locations"
+          ],
+          "additionalProperties": true,
+          "properties": {
+            "all_filtered_locations": {
+              "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations",
+              "type": "object",
+              "title": "The all_filtered_locations schema",
+              "examples": [
+                {
+                  "doc_count": 2,
+                  "all_nested_locations": {
+                    "doc_count": 1,
+                    "locations_name_keyword": {
+                      "doc_count_error_upper_bound": 0,
+                      "sum_other_doc_count": 0,
+                      "buckets": [
+                        {
+                          "key": "zurich",
+                          "doc_count": 1
+                        },
+                        {
+                          "key": "fribourg",
+                          "doc_count": 0
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "doc_count",
+                "all_nested_locations"
+              ],
+              "additionalProperties": true,
+              "properties": {
+                "doc_count": {
+                  "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/doc_count",
+                  "type": "integer",
+                  "title": "The doc_count schema",
+                  "default": 0,
+                  "examples": [
+                    2
+                  ]
+                },
+                "all_nested_locations": {
+                  "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations",
+                  "type": "object",
+                  "title": "The all_nested_locations schema",
+                  "examples": [
+                    {
+                      "doc_count": 1,
+                      "locations_name_keyword": {
+                        "doc_count_error_upper_bound": 0,
+                        "sum_other_doc_count": 0,
+                        "buckets": [
+                          {
+                            "key": "zurich",
+                            "doc_count": 1
+                          },
+                          {
+                            "key": "fribourg",
+                            "doc_count": 0
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "required": [
+                    "doc_count",
+                    "locations_name_keyword"
+                  ],
+                  "additionalProperties": true,
+                  "properties": {
+                    "doc_count": {
+                      "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/doc_count",
+                      "type": "integer",
+                      "title": "The doc_count schema",
+                      "default": 0,
+                      "examples": [
+                        1
+                      ]
+                    },
+                    "locations_name_keyword": {
+                      "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword",
+                      "type": "object",
+                      "title": "The locations_name_keyword schema",
+                      "examples": [
+                        {
+                          "doc_count_error_upper_bound": 0,
+                          "sum_other_doc_count": 0,
+                          "buckets": [
+                            {
+                              "key": "zurich",
+                              "doc_count": 1
+                            },
+                            {
+                              "key": "fribourg",
+                              "doc_count": 0
+                            },
+                            {
+                              "key": "Platformer",
+                              "doc_count": 0
+                            },
+                            {
+                              "key": "Puzzle",
+                              "doc_count": 0
+                            }
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "doc_count_error_upper_bound",
+                        "sum_other_doc_count",
+                        "buckets"
+                      ],
+                      "additionalProperties": true,
+                      "properties": {
+                        "doc_count_error_upper_bound": {
+                          "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/doc_count_error_upper_bound",
+                          "type": "integer",
+                          "title": "The doc_count_error_upper_bound schema",
+                          "default": 0,
+                          "examples": [
+                            0
+                          ]
+                        },
+                        "sum_other_doc_count": {
+                          "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/sum_other_doc_count",
+                          "type": "integer",
+                          "title": "The sum_other_doc_count schema",
+                          "default": 0,
+                          "examples": [
+                            0
+                          ]
+                        },
+                        "buckets": {
+                          "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets",
+                          "type": "array",
+                          "title": "The buckets schema",
+                          "default": [],
+                          "examples": [
+                            [
+                              {
+                                "key": "zurich",
+                                "doc_count": 1
+                              },
+                              {
+                                "key": "fribourg",
+                                "doc_count": 0
+                              }
+                            ]
+                          ],
+                          "additionalItems": true,
+                          "items": {
+                            "anyOf": [
+                              {
+                                "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items/anyOf/0",
+                                "type": "object",
+                                "title": "The first anyOf schema",
+                                "examples": [
+                                  {
+                                    "key": "zurich",
+                                    "doc_count": 1
+                                  }
+                                ],
+                                "required": [
+                                  "key",
+                                  "doc_count"
+                                ],
+                                "additionalProperties": true,
+                                "properties": {
+                                  "key": {
+                                    "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items/anyOf/0/properties/key",
+                                    "type": "string",
+                                    "title": "The key schema",
+                                    "default": "",
+                                    "examples": [
+                                      "zurich"
+                                    ]
+                                  },
+                                  "doc_count": {
+                                    "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items/anyOf/0/properties/doc_count",
+                                    "type": "integer",
+                                    "title": "The doc_count schema",
+                                    "default": 0,
+                                    "examples": [
+                                      1
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "$id": "#/properties/aggregations/properties/aggs_all/properties/all_filtered_locations/properties/all_nested_locations/properties/locations_name_keyword/properties/buckets/items"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/d8/sync/core.entity_form_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_form_display.node.game.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.game.field_genres
     - field.field.node.game.field_images
     - field.field.node.game.field_languages
+    - field.field.node.game.field_locations
     - field.field.node.game.field_members
     - field.field.node.game.field_path
     - field.field.node.game.field_publishers
@@ -93,10 +94,11 @@ third_party_settings:
       region: content
     group_meta:
       children:
+        - field_stores
+        - field_locations
         - field_languages
         - field_genres
         - field_sponsors
-        - field_stores
       parent_name: group_tabs
       weight: 23
       format_type: tab
@@ -157,7 +159,7 @@ content:
     type: string_textfield
     region: content
   field_genres:
-    weight: 5
+    weight: 10
     settings:
       match_operator: CONTAINS
       size: 60
@@ -177,7 +179,17 @@ content:
     type: image_focal_point
     region: content
   field_languages:
-    weight: 4
+    weight: 9
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_locations:
+    weight: 8
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -225,7 +237,7 @@ content:
     type: link_default
     region: content
   field_sponsors:
-    weight: 6
+    weight: 11
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/d8/sync/core.entity_form_display.taxonomy_term.location.default.yml
+++ b/config/d8/sync/core.entity_form_display.taxonomy_term.location.default.yml
@@ -1,0 +1,53 @@
+uuid: 5f0ad681-736f-4bc2-b165-833a40782019
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.location.field_path
+    - field.field.taxonomy_term.location.field_slug
+    - taxonomy.vocabulary.location
+  module:
+    - fieldable_path
+    - path
+id: taxonomy_term.location.default
+targetEntityType: taxonomy_term
+bundle: location
+mode: default
+content:
+  field_path:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: fieldable_path_widget
+    region: content
+  field_slug:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 4
+    region: content
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/d8/sync/core.entity_view_display.node.game.default.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.game.field_genres
     - field.field.node.game.field_images
     - field.field.node.game.field_languages
+    - field.field.node.game.field_locations
     - field.field.node.game.field_members
     - field.field.node.game.field_path
     - field.field.node.game.field_publishers
@@ -77,6 +78,14 @@ content:
     region: content
   field_languages:
     weight: 110
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_locations:
+    weight: 116
     label: above
     settings:
       link: true

--- a/config/d8/sync/core.entity_view_display.node.game.teaser.yml
+++ b/config/d8/sync/core.entity_view_display.node.game.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.game.field_genres
     - field.field.node.game.field_images
     - field.field.node.game.field_languages
+    - field.field.node.game.field_locations
     - field.field.node.game.field_members
     - field.field.node.game.field_path
     - field.field.node.game.field_publishers
@@ -47,6 +48,7 @@ hidden:
   field_genres: true
   field_images: true
   field_languages: true
+  field_locations: true
   field_members: true
   field_path: true
   field_publishers: true

--- a/config/d8/sync/core.entity_view_display.taxonomy_term.location.default.yml
+++ b/config/d8/sync/core.entity_view_display.taxonomy_term.location.default.yml
@@ -1,0 +1,39 @@
+uuid: b47c25fa-75af-4555-a3a2-a406df0eb6d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.location.field_path
+    - field.field.taxonomy_term.location.field_slug
+    - taxonomy.vocabulary.location
+  module:
+    - fieldable_path
+    - text
+id: taxonomy_term.location.default
+targetEntityType: taxonomy_term
+bundle: location
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_path:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: fieldable_path_formatter
+    region: content
+  field_slug:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/config/d8/sync/field.field.node.game.field_locations.yml
+++ b/config/d8/sync/field.field.node.game.field_locations.yml
@@ -1,0 +1,29 @@
+uuid: d091fbe7-5632-4906-8a17-5b6b689370ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_locations
+    - node.type.game
+    - taxonomy.vocabulary.location
+id: node.game.field_locations
+field_name: field_locations
+entity_type: node
+bundle: game
+label: Location(s)
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      location: location
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/d8/sync/field.field.taxonomy_term.location.field_path.yml
+++ b/config/d8/sync/field.field.taxonomy_term.location.field_path.yml
@@ -1,0 +1,23 @@
+uuid: 7563f564-fa8c-4427-a581-e774cc2e87b7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_path
+    - taxonomy.vocabulary.location
+  module:
+    - fieldable_path
+id: taxonomy_term.location.field_path
+field_name: field_path
+entity_type: taxonomy_term
+bundle: location
+label: Path
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: fieldable_path

--- a/config/d8/sync/field.field.taxonomy_term.location.field_slug.yml
+++ b/config/d8/sync/field.field.taxonomy_term.location.field_slug.yml
@@ -1,0 +1,19 @@
+uuid: f47fac72-79e7-45a6-b3f7-fee7419d7667
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_slug
+    - taxonomy.vocabulary.location
+id: taxonomy_term.location.field_slug
+field_name: field_slug
+entity_type: taxonomy_term
+bundle: location
+label: Slug
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/d8/sync/field.storage.node.field_locations.yml
+++ b/config/d8/sync/field.storage.node.field_locations.yml
@@ -1,0 +1,20 @@
+uuid: 1c38d9c9-2dc5-4a8a-b075-52e87f3e4ac7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_locations
+field_name: field_locations
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--game.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--game.yml
@@ -135,6 +135,18 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
+  field_article_links:
+    fieldName: field_article_links
+    publicName: field_article_links
+    enhancer:
+      id: ''
+    disabled: false
+  field_awards:
+    fieldName: field_awards
+    publicName: field_awards
+    enhancer:
+      id: ''
+    disabled: false
   field_genres:
     fieldName: field_genres
     publicName: genres
@@ -154,6 +166,18 @@ resourceFields:
             - medium
             - thumbnail
     disabled: false
+  field_languages:
+    fieldName: field_languages
+    publicName: field_languages
+    enhancer:
+      id: ''
+    disabled: false
+  field_locations:
+    fieldName: field_locations
+    publicName: field_locations
+    enhancer:
+      id: ''
+    disabled: false
   field_members:
     fieldName: field_members
     publicName: members
@@ -166,15 +190,45 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
+  field_publishers:
+    fieldName: field_publishers
+    publicName: field_publishers
+    enhancer:
+      id: ''
+    disabled: false
   field_releases:
     fieldName: field_releases
     publicName: releases
     enhancer:
       id: ''
     disabled: false
+  field_sources:
+    fieldName: field_sources
+    publicName: field_sources
+    enhancer:
+      id: ''
+    disabled: false
+  field_sponsors:
+    fieldName: field_sponsors
+    publicName: field_sponsors
+    enhancer:
+      id: ''
+    disabled: false
+  field_stores:
+    fieldName: field_stores
+    publicName: field_stores
+    enhancer:
+      id: ''
+    disabled: false
   field_studios:
     fieldName: field_studios
     publicName: studios
+    enhancer:
+      id: ''
+    disabled: false
+  field_website:
+    fieldName: field_website
+    publicName: field_website
     enhancer:
       id: ''
     disabled: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--location.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--location.yml
@@ -1,0 +1,131 @@
+uuid: a95051d1-2a6e-4883-8164-9136dbc9ed36
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.location
+id: taxonomy_term--location
+disabled: false
+path: taxonomy_term/location
+resourceType: taxonomy_term--location
+resourceFields:
+  tid:
+    fieldName: tid
+    publicName: tid
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_id:
+    disabled: true
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  vid:
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_created:
+    disabled: true
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: true
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: true
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: true
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    disabled: true
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  parent:
+    disabled: true
+    fieldName: parent
+    publicName: parent
+    enhancer:
+      id: ''
+  changed:
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: true
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  path:
+    disabled: true
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  field_path:
+    disabled: true
+    fieldName: field_path
+    publicName: field_path
+    enhancer:
+      id: ''
+  field_slug:
+    fieldName: field_slug
+    publicName: slug
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/d8/sync/pathauto.pattern.locations.yml
+++ b/config/d8/sync/pathauto.pattern.locations.yml
@@ -1,0 +1,23 @@
+uuid: 37534ed5-3219-4fd8-b62a-234e6a42bb37
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: locations
+label: Locations
+type: 'canonical_entities:taxonomy_term'
+pattern: '/locations/[term:name]'
+selection_criteria:
+  3df2bb35-b0a9-440c-aa7e-fe4c0d372374:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      location: location
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: 3df2bb35-b0a9-440c-aa7e-fe4c0d372374
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/d8/sync/taxonomy.vocabulary.location.yml
+++ b/config/d8/sync/taxonomy.vocabulary.location.yml
@@ -1,0 +1,8 @@
+uuid: c2772cd9-09af-4ff1-a779-34a8e71fa27e
+langcode: en
+status: true
+dependencies: {  }
+name: Location
+vid: location
+description: ''
+weight: 0

--- a/web/modules/custom/gos_default_content/content/node/08952aa6-e079-496a-8efa-cbb8465d9315.json
+++ b/web/modules/custom/gos_default_content/content/node/08952aa6-e079-496a-8efa-cbb8465d9315.json
@@ -36,6 +36,11 @@
                 "href": "http:\/\/default\/languages\/spanish?_format=hal_json"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "href": "http:\/\/default\/locations\/zurich?_format=hal_json"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_publishers": [
             {
                 "href": "http:\/\/default\/publishers\/astragon?_format=hal_json"
@@ -207,6 +212,23 @@
                 "uuid": [
                     {
                         "value": "83ce6271-20fa-4f84-949f-d43a9e40bc8c"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/locations\/zurich?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "e181208c-fd4d-47bc-9767-4965d670bc2f"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/node/12b7a617-4c66-4fb1-adf0-0ad70b775b9c.json
+++ b/web/modules/custom/gos_default_content/content/node/12b7a617-4c66-4fb1-adf0-0ad70b775b9c.json
@@ -22,6 +22,14 @@
                 "href": "http:\/\/default\/taxonomy\/term\/20?_format=hal_json"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "href": "http:\/\/default\/locations\/fribourg?_format=hal_json"
+            },
+            {
+                "href": "http:\/\/default\/locations\/geneva?_format=hal_json"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_members": [
             {
                 "href": "http:\/\/default\/people\/jeremy-wuthrer-cuany?_format=hal_json"
@@ -109,6 +117,38 @@
                 "uuid": [
                     {
                         "value": "e56e5642-6a2b-4dc1-96c2-924bd7b6de37"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/locations\/fribourg?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "e022f6e4-85e7-485e-a7dd-b92d0ab0e637"
+                    }
+                ]
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/locations\/geneva?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "ba6a9306-faa9-4823-b373-9f4dce01ca9e"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/node/9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd.json
+++ b/web/modules/custom/gos_default_content/content/node/9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd.json
@@ -30,6 +30,11 @@
                 "href": "http:\/\/default\/languages\/english?_format=hal_json"
             }
         ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "href": "http:\/\/default\/locations\/fribourg?_format=hal_json"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_members": [
             {
                 "href": "http:\/\/default\/people\/jeremy-wuthrer-cuany?_format=hal_json"
@@ -152,6 +157,23 @@
                 "uuid": [
                     {
                         "value": "c748e76c-4a40-4b04-9e69-17ea602cb0b0"
+                    }
+                ]
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/node\/game\/field_locations": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/locations\/fribourg?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "e022f6e4-85e7-485e-a7dd-b92d0ab0e637"
                     }
                 ]
             }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/03db2f32-1f7c-4d35-a2c9-42f951ae0bd8.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/03db2f32-1f7c-4d35-a2c9-42f951ae0bd8.json
@@ -90,5 +90,11 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "xbox_one",
+            "lang": "en"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/1bf8672b-f341-4287-8aa5-9b16c9131441.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/1bf8672b-f341-4287-8aa5-9b16c9131441.json
@@ -90,5 +90,10 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "simulation"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/304a43fe-3c4d-4587-93e6-a84959d39bf7.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/304a43fe-3c4d-4587-93e6-a84959d39bf7.json
@@ -90,5 +90,11 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "pc",
+            "lang": "en"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/9e1f8365-4bf3-4189-bf33-c9ac6862dca7.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/9e1f8365-4bf3-4189-bf33-c9ac6862dca7.json
@@ -90,5 +90,11 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "mac",
+            "lang": "en"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/ba6a9306-faa9-4823-b373-9f4dce01ca9e.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/ba6a9306-faa9-4823-b373-9f4dce01ca9e.json
@@ -1,0 +1,106 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/locations\/geneva?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 33
+        }
+    ],
+    "uuid": [
+        {
+            "value": "ba6a9306-faa9-4823-b373-9f4dce01ca9e"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 33
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "location"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-06-19T14:54:11+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Geneva",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-06-19T14:54:11+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/locations\/geneva",
+            "pid": 21,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/locations\/geneva",
+            "lang": "en"
+        }
+    ],
+    "field_slug": [
+        {
+            "value": "geneva",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/c80a976b-749c-496d-906c-e6833e46e086.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/c80a976b-749c-496d-906c-e6833e46e086.json
@@ -90,5 +90,10 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "adventure"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/e022f6e4-85e7-485e-a7dd-b92d0ab0e637.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/e022f6e4-85e7-485e-a7dd-b92d0ab0e637.json
@@ -1,0 +1,106 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/locations\/fribourg?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 35
+        }
+    ],
+    "uuid": [
+        {
+            "value": "e022f6e4-85e7-485e-a7dd-b92d0ab0e637"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 35
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "location"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-06-19T14:56:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Fribourg",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-06-19T14:56:57+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/locations\/fribourg",
+            "pid": 24,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/locations\/fribourg",
+            "lang": "en"
+        }
+    ],
+    "field_slug": [
+        {
+            "value": "fribourg",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/e181208c-fd4d-47bc-9767-4965d670bc2f.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/e181208c-fd4d-47bc-9767-4965d670bc2f.json
@@ -1,0 +1,106 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/default\/locations\/zurich?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/location"
+        },
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "tid": [
+        {
+            "value": 34
+        }
+    ],
+    "uuid": [
+        {
+            "value": "e181208c-fd4d-47bc-9767-4965d670bc2f"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 34
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "location"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2020-06-19T14:54:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Z\u00fcrich",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/taxonomy_term\/location\/parent": [
+            null
+        ]
+    },
+    "changed": [
+        {
+            "value": "2020-06-19T14:54:45+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": "\/locations\/zurich",
+            "pid": 23,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ],
+    "field_path": [
+        {
+            "value": "\/locations\/zurich",
+            "lang": "en"
+        }
+    ],
+    "field_slug": [
+        {
+            "value": "zurich",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/e56e5642-6a2b-4dc1-96c2-924bd7b6de37.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/e56e5642-6a2b-4dc1-96c2-924bd7b6de37.json
@@ -90,5 +90,10 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "platformer"
+        }
     ]
 }

--- a/web/modules/custom/gos_default_content/content/taxonomy_term/e5b2685e-39a7-4726-ad90-d7e3b44c2850.json
+++ b/web/modules/custom/gos_default_content/content/taxonomy_term/e5b2685e-39a7-4726-ad90-d7e3b44c2850.json
@@ -90,5 +90,11 @@
             "langcode": "en",
             "lang": "en"
         }
+    ],
+    "field_slug": [
+        {
+            "value": "playstation_4",
+            "lang": "en"
+        }
     ]
 }

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
@@ -164,6 +164,15 @@ class GameNodeIndex extends NodeIndexBase {
                 ],
               ],
             ],
+            'locations' => [
+              'dynamic' => FALSE,
+              'type' => 'nested',
+              'properties' => [
+                'slug' => [
+                  'type' => 'keyword',
+                ],
+              ],
+            ],
             'stores' => [
               'dynamic' => FALSE,
               'type' => 'nested',

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/Normalizer/GameNormalizer.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/Normalizer/GameNormalizer.php
@@ -94,6 +94,19 @@ class GameNormalizer extends ContentEntityNormalizer {
       $data['stores'] = $genres;
     }
 
+    // Handle locations.
+    if (!$object->get('field_locations')->isEmpty()) {
+      $locations = [];
+
+      foreach ($object->field_locations as $location) {
+        $locations[] = [
+          'slug' => $location->entity->get('field_slug')->value,
+        ];
+      }
+
+      $data['locations'] = $locations;
+    }
+
     return $data;
   }
 

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -50,6 +50,15 @@ class ElasticGamesResourceValidator extends BaseValidator {
   private $genres;
 
   /**
+   * The game Locations to filter by.
+   *
+   * This field uses the custom validation ::validateLocations.
+   *
+   * @var \Drupal\taxonomy\TermInterface[]|null
+   */
+  private $locations;
+
+  /**
    * The page to fetch.
    *
    * The page parameter is mandatory to avoid search overload.
@@ -95,6 +104,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function getGenres(): ?array {
     return $this->genres;
+  }
+
+  /**
+   * Get the game Locations to filter by.
+   *
+   * @return \Drupal\taxonomy\TermInterface[]|null
+   *   Locations to filter by.
+   */
+  public function getLocations(): ?array {
+    return $this->locations;
   }
 
   /**
@@ -155,6 +174,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function setGenres(array $genres): void {
     $this->genres = $genres;
+  }
+
+  /**
+   * Set the Locations to filter by.
+   *
+   * @param \Drupal\taxonomy\TermInterface[] $locations
+   *   Locations to filter by.
+   */
+  public function setLocations(array $locations): void {
+    $this->locations = $locations;
   }
 
   /**
@@ -223,6 +252,26 @@ class ElasticGamesResourceValidator extends BaseValidator {
     if (isset($this->raw['genres']) && !$this->genres) {
       $context->buildViolation(sprintf('At least one given Genre(s) has not been found.'))
         ->atPath('genres')
+        ->addViolation();
+    }
+  }
+
+  /**
+   * Validates the Locations parameter.
+   *
+   * Ensure the given taxonomy is a proper Genres entity.
+   *
+   * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
+   *   The validation execution context.
+   * @param string $payload
+   *   The Payload.
+   *
+   * @Assert\Callback
+   */
+  public function validateLocations(ExecutionContextInterface $context, $payload): void {
+    if (isset($this->raw['locations']) && !$this->locations) {
+      $context->buildViolation(sprintf('At least one given Location(s) has not been found.'))
+        ->atPath('locations')
         ->addViolation();
     }
   }

--- a/web/modules/custom/gos_migrate/README.md
+++ b/web/modules/custom/gos_migrate/README.md
@@ -34,6 +34,12 @@ Before starting a migration,
   $ drush mim gos_genres
   ```
 
+1. Migrate all locations (Zürich, Fribourg, ...)
+
+  ```bash
+  $ drush mim gos_locations
+  ```
+
 1. Migrate all studios with appropriates team-member(s)
 
   ```bash

--- a/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
+++ b/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
@@ -37,7 +37,7 @@ source:
     4:
       name: studios
     5:
-      name: location
+      name: locations
     6:
       name: publishers
     7:
@@ -203,6 +203,33 @@ process:
             value_key: name
             bundle_key: vid
             bundle: genre
+            entity_type: taxonomy_term
+            ignore_case: true
+            access_check: false
+
+  field_locations:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: locations
+    -
+      plugin: explode
+      delimiter: ","
+      limit: 10
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: trim
+            source: 'value'
+          -
+            plugin: entity_lookup
+            value_key: name
+            bundle_key: vid
+            bundle: location
             entity_type: taxonomy_term
             ignore_case: true
             access_check: false
@@ -382,3 +409,4 @@ migration_dependencies:
     - default:gos_studios
     - default:gos_platforms
     - default:gos_genres
+    - default:gos_locations

--- a/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
+++ b/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_games.yml
@@ -400,6 +400,10 @@ process:
     plugin: image_import
     source: screenshot_link
 
+  uid:
+    plugin: default_value
+    default_value: 1
+
 destination:
   plugin: entity:node
   default_bundle: game

--- a/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_locations.yml
+++ b/web/modules/custom/gos_migrate/migrations/migrate_plus.migration.gos_locations.yml
@@ -1,0 +1,85 @@
+id: gos_locations
+label: Games of Switzerland - Locations
+description: GOS - Migration of Locations from CSV to Drupal 8
+migration_group: default
+
+source:
+  plugin: 'csv'
+  # Full path to the file.
+  path: '/source/2020-17-05--all-games.csv'
+  # Column delimiter. Comma (,) by default.
+  delimiter: ','
+  # Field enclosure. Double quotation marks (") by default.
+  enclosure: '"'
+  # The row to be used as the CSV header (indexed from 0),
+  # or null if there is no header row.
+  header_offset: 0
+#  # The column(s) to use as a key. Each column specified will
+#  # create an index in the migration table and too many columns
+#  # may throw an index size error.
+  ids:
+    - id
+  # Here we identify the columns of interest in the source file.
+  # Each numeric key is the 0-based index of the column.
+  # For each column, the key below is the field name assigned to
+  # the data on import, to be used in field mappings below.
+  # The label value is a user-friendly string for display by the
+  # migration UI.
+  fields:
+    0:
+      name: game_title
+    1:
+      name: id
+    2:
+      name: platforms
+    3:
+      name: website
+    4:
+      name: studios
+    5:
+      name: locations
+    6:
+      name: publisher
+    7:
+      name: sponsor
+    8:
+      name: early_access_date
+    9:
+      name: release_date
+    10:
+      name: languages
+    11:
+      name: media
+    12:
+      name: genres
+
+process:
+  name:
+    -
+      plugin: skip_on_empty
+      method: row
+      source: locations
+    -
+      plugin: explode
+      delimiter: ","
+      limit: 10
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        title:
+          -
+            plugin: trim
+            source: 'value'
+          -
+            plugin: entity_generate
+            value_key: name
+            bundle_key: vid
+            bundle: location
+            entity_type: taxonomy_term
+            ignore_case: true
+
+
+destination:
+  plugin: noop

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -117,6 +117,18 @@
             "uniqueItems": true
           },
           {
+            "name": "locations[]",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "description": "Collection of locations slug. Items are matched using an Inner OR condition.",
+            "items": {
+              "type": "string"
+            },
+            "example": "zurich",
+            "uniqueItems": true
+          },
+          {
             "name": "stores[]",
             "in": "query",
             "required": false,


### PR DESCRIPTION
### 💬 Describe the pull request
A clear and concise description of what the pull request is about.

### 🗃️ Issues
This pull request is related to :
- close #8 

### 🚧 What has been done

- new Taxonomy Location
- Pathauto for Location
- Json:API exposition of Location
- 3 new default content for Language
- Locations field in Games
- Behat coverage of vocabulary Location
- Add Locations' games to Elasticsearch
- Allow filtering by Locations slug
- Behat coverage of ES filtering by Location(s)

### 🚧 Work in progress

- Add migrations of Location

### 🔢 To Review
Steps to review the PR:

1. `drush cim -y && drush cr`
2. Games should be able to have Location(s)
3. You should be able to create Location as Taxonomy
3. Created Location will automatically have a slug if not defined during CRUD.
3. Location should be migrated on `drush mim gos_locations`
3. Location should be lookuped on `drush mim gos_games`
