### PR TITLE
update json:api fields name normalization

### DIFF
--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--game.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--game.yml
@@ -137,13 +137,13 @@ resourceFields:
     disabled: false
   field_article_links:
     fieldName: field_article_links
-    publicName: field_article_links
+    publicName: article_links
     enhancer:
       id: ''
     disabled: false
   field_awards:
     fieldName: field_awards
-    publicName: field_awards
+    publicName: awards
     enhancer:
       id: ''
     disabled: false
@@ -174,13 +174,13 @@ resourceFields:
     disabled: false
   field_languages:
     fieldName: field_languages
-    publicName: field_languages
+    publicName: languages
     enhancer:
       id: ''
     disabled: false
   field_locations:
     fieldName: field_locations
-    publicName: field_locations
+    publicName: locations
     enhancer:
       id: ''
     disabled: false
@@ -198,7 +198,7 @@ resourceFields:
     disabled: false
   field_publishers:
     fieldName: field_publishers
-    publicName: field_publishers
+    publicName: publishers
     enhancer:
       id: ''
     disabled: false
@@ -216,19 +216,19 @@ resourceFields:
     disabled: false
   field_sources:
     fieldName: field_sources
-    publicName: field_sources
+    publicName: sources
     enhancer:
       id: ''
     disabled: false
   field_sponsors:
     fieldName: field_sponsors
-    publicName: field_sponsors
+    publicName: sponsors
     enhancer:
       id: ''
     disabled: false
   field_stores:
     fieldName: field_stores
-    publicName: field_stores
+    publicName: stores
     enhancer:
       id: ''
     disabled: false
@@ -240,7 +240,7 @@ resourceFields:
     disabled: false
   field_website:
     fieldName: field_website
-    publicName: field_website
+    publicName: website
     enhancer:
       id: ''
     disabled: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--people.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--people.yml
@@ -123,9 +123,21 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
   body:
     fieldName: body
     publicName: body
+    enhancer:
+      id: ''
+    disabled: false
+  field_path:
+    fieldName: field_path
+    publicName: field_path
     enhancer:
       id: ''
     disabled: false

--- a/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--studio.yml
+++ b/config/d8/sync/jsonapi_extras.jsonapi_resource_config.node--studio.yml
@@ -123,6 +123,12 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
+  menu_link:
+    disabled: true
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
   body:
     fieldName: body
     publicName: body
@@ -132,6 +138,12 @@ resourceFields:
   field_members:
     fieldName: field_members
     publicName: members
+    enhancer:
+      id: ''
+    disabled: false
+  field_path:
+    fieldName: field_path
+    publicName: field_path
     enhancer:
       id: ''
     disabled: false


### PR DESCRIPTION
update json:api fields name by removing prefix `field_` excepted for `path` (as original `path` already exists and would collide)
