### PR TITLE
ensure when generating pattern for Elasticsearch

### DIFF
--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/NodeIndexBase.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/NodeIndexBase.php
@@ -137,4 +137,19 @@ abstract class NodeIndexBase extends ElasticsearchIndexBase {
     parent::index($entity);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function indexNamePattern() {
+    if (!$this->settings::get(self::SETTINGS_INDEX_PREFIX)) {
+      throw new InvalidArgumentException('No index prefix was specified in settings.php.');
+    }
+
+    // Always specify the placeholder `index_prefix`.
+    $index_prefix = $this->settings::get(self::SETTINGS_INDEX_PREFIX);
+    $index_name = str_replace('{index_prefix}', $index_prefix, $this->pluginDefinition['indexName']);
+
+    return preg_replace($this->placeholder_regex, '*', $index_name);
+  }
+
 }


### PR DESCRIPTION
Will always use the proper configured index_prefix and not a wildcard #66

### 🗃️ Issues
This pull request is related to :
- close #66