### PR TITLE
index unpublished item

### DIFF
--- a/behat/Features/elasticsearch/search.games.locations.facets.feature
+++ b/behat/Features/elasticsearch/search.games.locations.facets.feature
@@ -14,12 +14,14 @@
     Given I send a "GET" request to <url>
     Then the response status code should be 200
     And the response should be in JSON
-    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 2 elements
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 3 elements
     And the JSON nodes should be equal to:
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | fribourg |
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | zurich |
       | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 1 |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | geneva |
+      | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 0 |
     Examples:
       | url |
       | "http://api.gos.test/search/games?page=0" |
@@ -27,16 +29,21 @@
 
     Scenario: The Locations facets/aggregations should be affected by filtered Stores and/or Platforms.
       Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=ios"
-    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 2 elements
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 3 elements
       And the JSON nodes should be equal to:
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | fribourg |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 0 |
-        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | zurich |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | geneva |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 0 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | zurich |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 0 |
+
       Given I send a "GET" request to "http://api.gos.test/search/games?page=0&stores[]=steam"
-    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 2 elements
+    And the JSON node "aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets" should have 3 elements
       And the JSON nodes should be equal to:
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].key | zurich |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[0].doc_count | 1 |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].key | fribourg |
         | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[1].doc_count | 0 |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].key | geneva |
+        | aggregations.aggs_all.all_filtered_locations.all_nested_locations.locations_name_keyword.buckets[2].doc_count | 0 |

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/NodeIndexBase.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/NodeIndexBase.php
@@ -129,11 +129,6 @@ abstract class NodeIndexBase extends ElasticsearchIndexBase {
     /** @var \Drupal\node\NodeInterface $entity */
     $entity = $source;
 
-    // Skip unpublished people.
-    if (!$entity->isPublished()) {
-      return;
-    }
-
     parent::index($entity);
   }
 


### PR DESCRIPTION
### 💬 Describe the pull request

We have to index "unpublished" node and filter them out from the REST bridge.

Indeed, if we don't index them, then the Elasticsearch Helper will not be able to "update" the node to "Publish" from Drupal. As the Helper only try an "update" call and not a "create or update" one. Therefore we should always index every node then filter them out if unpublished.