### PR TITLE
Release years aggregations & filtering

### DIFF
--- a/behat/Features/elasticsearch/search.games.release_years.facets.feature
+++ b/behat/Features/elasticsearch/search.games.release_years.facets.feature
@@ -1,0 +1,43 @@
+@elasticsearch
+  Feature: Retrieve Games Release Years facets from Elasticsearch
+  In order to filter the Games Search API
+  As a client software developer
+  I need to be able to fetch faceted Release Years in a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: The Release Years facets/aggregations should follow a strict given structure.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0"
+    Then the response status code should be 200
+    And the response should be in JSON
+    Then the JSON should be valid according to the schema "/var/www/behat/Fixtures/elasticsearch/schemaref.search.games.release_years.facets.json"
+
+  Scenario Outline: The Release Years facets/aggregations should use the same filter as the global query - without itself as filter.
+    Given I send a "GET" request to <url>
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets" should have 2 elements
+    And the JSON nodes should be equal to:
+      | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[0].key_as_string | 2017 |
+      | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[0].doc_count | 1 |
+      | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[1].key_as_string | 2018 |
+      | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[1].doc_count | 2 |
+    Examples:
+      | url |
+      | "http://api.gos.test/search/games?page=0" |
+      | "http://api.gos.test/search/games?page=0&release_year=2017" |
+
+    Scenario: The Release Years facets/aggregations should be affected by filtered Stores and/or Platforms.
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=ios"
+    And the JSON node "aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets" should have 2 elements
+      And the JSON nodes should be equal to:
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[0].key_as_string | 2017 |
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[0].doc_count | 1 |
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[1].key_as_string | 2018 |
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[1].doc_count | 1 |
+
+      Given I send a "GET" request to "http://api.gos.test/search/games?page=0&platforms[]=pc"
+    And the JSON node "aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets" should have 2 elements
+      And the JSON nodes should be equal to:
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[0].key_as_string | 2017 |
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[0].doc_count | 1 |
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[1].key_as_string | 2018 |
+        | aggregations.aggs_all.all_filtered_release_years_histogram.all_nested_release_years.releases_over_time.buckets[1].doc_count | 2 |

--- a/behat/Features/elasticsearch/search.games.release_years.feature
+++ b/behat/Features/elasticsearch/search.games.release_years.feature
@@ -1,0 +1,22 @@
+@elasticsearch
+  Feature: Retrieve Games items from Elasticsearch
+  In order to use a Games Search API
+  As a client software developer
+  I need to be able to filter by Release Year a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: Games Resource should respond with filtered games when a valid year date (YYYY) is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year=2017"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 1 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | a0b7c853-c891-487f-84f9-74dfbce9fa63 |
+
+    Scenario: Games Resource should respond with an error when a non-valid year date is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year=17"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the JSON node "errors.releaseYear" should exist
+    And the JSON node "errors.releaseYear" should have 1 element
+    And the JSON node "errors.releaseYear[0]" should be equal to "This value should be greater than or equal to 1970."

--- a/behat/Fixtures/elasticsearch/schemaref.search.games.release_years.facets.json
+++ b/behat/Fixtures/elasticsearch/schemaref.search.games.release_years.facets.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "aggregations": {
+      "type": "object",
+      "properties": {
+        "aggs_all": {
+          "type": "object",
+          "properties": {
+            "doc_count": {
+              "type": "integer"
+            },
+            "all_filtered_release_years_histogram": {
+              "type": "object",
+              "properties": {
+                "doc_count": {
+                  "type": "integer"
+                },
+                "all_nested_release_years": {
+                  "type": "object",
+                  "properties": {
+                    "doc_count": {
+                      "type": "integer"
+                    },
+                    "releases_over_time": {
+                      "type": "object",
+                      "properties": {
+                        "buckets": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "key_as_string": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "integer"
+                                },
+                                "doc_count": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "key_as_string",
+                                "key",
+                                "doc_count"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "key_as_string": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "integer"
+                                },
+                                "doc_count": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "key_as_string",
+                                "key",
+                                "doc_count"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "buckets"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "doc_count",
+                    "releases_over_time"
+                  ]
+                }
+              },
+              "required": [
+                "doc_count",
+                "all_nested_release_years"
+              ]
+            }
+          },
+          "required": [
+            "doc_count",
+            "all_filtered_release_years_histogram"
+          ]
+        }
+      },
+      "required": [
+        "aggs_all"
+      ]
+    }
+  },
+  "required": [
+    "aggregations"
+  ]
+}

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
@@ -174,6 +174,16 @@ class GameNodeIndex extends NodeIndexBase {
                 ],
               ],
             ],
+            'releases_years' => [
+              'type' => 'nested',
+              'dynamic' => FALSE,
+              'properties' => [
+                'year' => [
+                  'type' => 'date',
+                  'format' => 'yyyy',
+                ],
+              ],
+            ],
             'studios' => [
               'dynamic' => FALSE,
               'type' => 'nested',

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -79,6 +79,20 @@ class ElasticGamesResourceValidator extends BaseValidator {
   private $platforms;
 
   /**
+   * The game Release Year to filter by.
+   *
+   * @var int|null
+   *
+   * @Assert\Type(
+   *     type="integer",
+   * )
+   * @Assert\GreaterThanOrEqual(
+   *     value=1970
+   * )
+   */
+  private $releaseYear;
+
+  /**
    * Sort property with direction as key.
    *
    * This property uses the custom validation ::validateSort.
@@ -144,6 +158,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function getRaw(): array {
     return $this->raw;
+  }
+
+  /**
+   * Get the game Release year to filter by.
+   *
+   * @return int|null
+   *   Release year to filter by.
+   */
+  public function getReleaseYear(): ?int {
+    return $this->releaseYear;
   }
 
   /**
@@ -214,6 +238,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function setRaw(array $raw): void {
     $this->raw = $raw;
+  }
+
+  /**
+   * Set the Release year to filter by.
+   *
+   * @param int $year
+   *   Release year to filter by.
+   */
+  public function setReleaseYear(int $year): void {
+    $this->releaseYear = $year;
   }
 
   /**

--- a/web/modules/custom/gos_rest/src/Plugin/rest/ResourceValidator/BaseValidator.php
+++ b/web/modules/custom/gos_rest/src/Plugin/rest/ResourceValidator/BaseValidator.php
@@ -48,6 +48,8 @@ abstract class BaseValidator implements ArrayAccess {
    *   The value to get from given offset.
    */
   public function offsetGet($offset) {
+    $offset = $this->camelize($offset);
+
     if (!$this->offsetExists($offset)) {
       throw new InvalidArgumentException(sprintf('Unsupported offset %s.', $offset));
     }
@@ -66,6 +68,8 @@ abstract class BaseValidator implements ArrayAccess {
    *   The value to set.
    */
   public function offsetSet($offset, $value): void {
+    $offset = $this->camelize($offset);
+
     if (!$this->offsetExists($offset)) {
       throw new InvalidArgumentException(sprintf('Unsupported offset %s.', $offset));
     }
@@ -87,6 +91,21 @@ abstract class BaseValidator implements ArrayAccess {
    */
   public function offsetUnset($offset): void {
     throw new BadMethodCallException('Unsupported method.');
+  }
+
+  /**
+   * Transform a given snake_case input into lowerCamelCase form.
+   *
+   * @param string $input
+   *   The input to be transformed.
+   * @param string $separator
+   *   The snake_case separator.
+   *
+   * @return string
+   *   The lowerCamelCase value of given input.
+   */
+  private function camelize($input, $separator = '_'): string {
+    return str_replace($separator, '', lcfirst(ucwords($input, $separator)));
   }
 
 }

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -151,6 +151,14 @@
             },
             "example": "ps4",
             "uniqueItems": true
+          },
+          {
+            "name": "release_year",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "The year to filter games by.",
+            "example": "2019"
           }
         ],
         "responses": {
@@ -195,7 +203,7 @@
           }
         }
       }
-    },
+    }
   },
   "securityDefinitions": {
     "csrf_token": {


### PR DESCRIPTION
### 💬 Describe the pull request
A clear and concise description of what the pull request is about.

### 🗃️ Issues
This pull request is related to :
- close #43 

### 🔢 To Review
Steps to review the PR:
1. Access the Game endpoint `/search/games?page=0`

You should now see a new bucket `aggregations.aggs_all.all_filtered_release_years_histogram`.

```json
"all_filtered_release_years_histogram": {
	"doc_count": 4,
	"all_nested_release_years": {
		"doc_count": 3,
		"releases_over_time": {
			"buckets": [{
					"key_as_string": "2017",
					"key": 1483228800000,
					"doc_count": 1
				},
				{
					"key_as_string": "2018",
					"key": 1514764800000,
					"doc_count": 2
				}
			]
		}
	}
},
```

2. You should also be able to filter games by `release_year`

```
/search/games?page=0&release_year=2017
```

### 🌩 API Swagger documentation
If applicable, add swagger API endpoints to help explain the usage.
