### PR TITLE
fulltext search of games

### DIFF
--- a/behat/Features/elasticsearch/search.games.q.feature
+++ b/behat/Features/elasticsearch/search.games.q.feature
@@ -1,0 +1,42 @@
+@elasticsearch
+  Feature: Retrieve Games items from Elasticsearch
+  In order to use a Games Search API
+  As a client software developer
+  I need to be able to filter by Keywords on Game Title a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario Outline: Games Resource should respond with filtered games when a keyword(s) search "q" is given.
+    Given I send a "GET" request to <url>
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 1 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | 9bb9538f-5b75-4dc0-99b1-ff11d4e2abdd |
+      | hits.hits[0]._source.title | Don't kill Her |
+    Examples:
+      | url |
+      | "http://api.gos.test/search/games?page=0&q=kill" |
+      | "http://api.gos.test/search/games?page=0&q=KiLL" |
+      | "http://api.gos.test/search/games?page=0&q=her" |
+      | "http://api.gos.test/search/games?page=0&q=don't%20kill%20her" |
+
+  Scenario: Games Resource should respond with no results when keywords does not match any game.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&q=giants"
+    And the JSON node "hits.hits" should have 0 element
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&q=jérémy"
+    And the JSON node "hits.hits" should have 0 element
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&q=wuthrer"
+    And the JSON node "hits.hits" should have 0 element
+
+  Scenario: Games Resource should respond with filtered games with very accurate precision more keywords we add.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&q=farming"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 2 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON node "hits.hits[1]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | a0b7c853-c891-487f-84f9-74dfbce9fa63 |
+      | hits.hits[0]._source.title | Farming Simulator 18 |
+      | hits.hits[1]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
+      | hits.hits[1]._source.title | Farming Simulator 19 |

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/ElasticsearchIndex/GameNodeIndex.php
@@ -55,7 +55,7 @@ class GameNodeIndex extends NodeIndexBase {
               'people_fullname_filter' => [
                 'type' => 'edge_ngram',
                 'min_gram' => 2,
-                'max_gram' => 10,
+                'max_gram' => 50,
                 'token_chars' => [
                   'letter',
                 ],
@@ -63,7 +63,7 @@ class GameNodeIndex extends NodeIndexBase {
               'studio_name_filter' => [
                 'type' => 'edge_ngram',
                 'min_gram' => 3,
-                'max_gram' => 10,
+                'max_gram' => 128,
                 'token_chars' => [
                   'letter',
                   'digit',
@@ -71,11 +71,14 @@ class GameNodeIndex extends NodeIndexBase {
               ],
             ],
             'analyzer' => [
-              'ngram_gametitle_analyzer' => [
-                'tokenizer' => 'ngram_gametitle_tokenizer',
-                'filter' => ['lowercase'],
+              'game_title_analyzer' => [
+                'tokenizer' => 'game_title_tokenizer',
+                'filter' => [
+                  'lowercase',
+                  'asciifolding',
+                ],
               ],
-              'ngram_gametitle_analyzer_search' => [
+              'game_title_analyzer_search' => [
                 'tokenizer' => 'lowercase',
               ],
               'english_language_analyzer' => [
@@ -114,10 +117,10 @@ class GameNodeIndex extends NodeIndexBase {
               ],
             ],
             'tokenizer' => [
-              'ngram_gametitle_tokenizer' => [
+              'game_title_tokenizer' => [
                 'type' => 'edge_ngram',
                 'min_gram' => 2,
-                'max_gram' => 10,
+                'max_gram' => 255,
                 'token_chars' => [
                   'letter',
                   'digit',
@@ -142,8 +145,8 @@ class GameNodeIndex extends NodeIndexBase {
             ],
             'title' => [
               'type' => 'text',
-              'analyzer' => 'ngram_gametitle_analyzer',
-              'search_analyzer' => 'ngram_gametitle_analyzer_search',
+              'analyzer' => 'game_title_analyzer',
+              'search_analyzer' => 'game_title_analyzer_search',
               'fields' => [
                 'keyword' => [
                   'type' => 'keyword',

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -32,6 +32,13 @@ class ElasticGamesResourceValidator extends BaseValidator {
   ];
 
   /**
+   * The search keywords.
+   *
+   * @var string
+   */
+  protected $q;
+
+  /**
    * All raw element.
    *
    * This field may used in custom validators.
@@ -151,6 +158,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
+   * Get the search keywords.
+   *
+   * @return string|null
+   *   Keywords to filter by.
+   */
+  public function getQ(): ?string {
+    return $this->q;
+  }
+
+  /**
    * Get the raw values.
    *
    * @return array
@@ -228,6 +245,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function setPlatforms(array $platforms): void {
     $this->platforms = $platforms;
+  }
+
+  /**
+   * Set the Keywords to filter by.
+   *
+   * @param string $search
+   *   Keywords to filter by.
+   */
+  public function setQ(string $search): void {
+    $this->q = $search;
   }
 
   /**

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -79,6 +79,13 @@
             "default": 0
           },
           {
+            "name": "q",
+            "in": "query",
+            "description": "Keywords to use for the search",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "sort[asc]",
             "in": "query",
             "required": false,


### PR DESCRIPTION
### 💬 Describe the pull request

Allow fulltext games title search.

### 🗃️ Issues
This pull request is related to :
- close #5

### 🔢 To Review
Steps to review the PR:
1. Use the new `q` parameter on the `search/games` endpoint.
2. Go to `search/games?page=0&q=farming`

The results should be filtered by `farming` keyword.

### 🌩 API Swagger documentation

- A new `string` property named `q` is available on `search/games`