### PR TITLE
ensure games, people & studio are redirected to React/Next app from Drupal 'Canonical access'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,22 @@ db:
 
 ### Project setup
 
-Once the project up and running via Docker, you may need to setup some configurations in the `web/sites/default/setting.php`
+Once the project up and running via Docker, you may need to setup some configurations in the `web/sites/default/setting.php`.
+
+#### Project base URL
+
+As we are working in a decoupled architecture, we need to set the Website URL.
+
+```php
+/**
+ * Base URL of the Next App.
+ *
+ * This value should not contain a leading slash (/).
+ *
+ * @var string
+ */
+$config['frontend']['base_url'] = 'https://gos.museebolo.ch';
+```
 
 #### Elasticsearch prefix
 

--- a/behat/Features/redirects/game.feature
+++ b/behat/Features/redirects/game.feature
@@ -1,0 +1,8 @@
+Feature: Game node redirection
+
+  @redirect_disable
+  Scenario: Accessing a node Game page should permanently redirect you to the Next/React app.
+    Given I am on "/node/12"
+    Then the response status code should be 301
+    Then I should be redirected to "https://gos.museebolo.ch/games/farming-simulator-19"
+

--- a/behat/Features/redirects/people.feature
+++ b/behat/Features/redirects/people.feature
@@ -1,0 +1,8 @@
+Feature: People node redirection
+
+  @redirect_disable
+  Scenario: Accessing a node People page should permanently redirect you to the Next/React app.
+    Given I am on "/node/13"
+    Then the response status code should be 301
+    Then I should be redirected to "https://gos.museebolo.ch/people/jeremy-wuthrer-cuany"
+

--- a/behat/Features/redirects/studio.feature
+++ b/behat/Features/redirects/studio.feature
@@ -1,0 +1,8 @@
+Feature: Studio node redirection
+
+  @redirect_disable
+  Scenario: Accessing a node Studio page should permanently redirect you to the Next/React app.
+    Given I am on "/node/15"
+    Then the response status code should be 301
+    Then I should be redirected to "https://gos.museebolo.ch/studios/giants-software"
+

--- a/web/modules/custom/gos_site/gos_site.services.yml
+++ b/web/modules/custom/gos_site/gos_site.services.yml
@@ -1,10 +1,23 @@
 services:
+  gos_site.node_reroute:
+    class: Drupal\gos_site\EventSubscriber\NodeEntityReroute
+    arguments:
+      - '@current_route_match'
+      - '@language_manager'
+      - '@gos_site.url_builder.nextjs'
+    tags:
+      - {name: event_subscriber}
 
   gos_site.taxonomy_reroute:
     class: Drupal\gos_site\EventSubscriber\TaxonomyEntityReroute
     arguments:
       - '@current_route_match'
       - '@language_manager'
+      - '@gos_site.url_builder.nextjs'
     tags:
       - {name: event_subscriber}
 
+  gos_site.url_builder.nextjs:
+    class: Drupal\gos_site\UrlBuilderNextJs
+    arguments:
+      - '@config.factory'

--- a/web/modules/custom/gos_site/src/EventSubscriber/NodeEntityReroute.php
+++ b/web/modules/custom/gos_site/src/EventSubscriber/NodeEntityReroute.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\gos_site\EventSubscriber;
+
+use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirect Drupal canonical to pages in Next app.
+ */
+class NodeEntityReroute extends BaseEntityReroute implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::REQUEST => [
+        ['isPage'],
+        ['isGame'],
+        ['isPeople'],
+        ['isStudio'],
+      ],
+    ];
+  }
+
+  /**
+   * Redirect Game canonical to Next/React page.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   A response for a request.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function isGame(GetResponseEvent $event): void {
+    $request = $event->getRequest();
+    $response = $this->redirectFromNode('game', $request);
+
+    if ($response) {
+      $event->setResponse($response);
+    }
+  }
+
+  /**
+   * Redirect Page canonical to no-where.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   A response for a request.
+   */
+  public function isPage(GetResponseEvent $event): void {
+    /** @var \Drupal\Core\Entity\ContentEntityBase $node */
+    $node = $this->routeMatch->getParameter('node');
+    $route_name = $this->routeMatch->getRouteName();
+
+    if ($route_name === 'entity.node.canonical' && $node->bundle() === 'page') {
+      /** @var string $dest */
+      $dest = Url::fromRoute('<front>')->toString();
+      $response = $this->buildRedirection($dest, $node);
+      $event->setResponse($response);
+    }
+  }
+
+  /**
+   * Redirect People canonical to Next/React page.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   A response for a request.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function isPeople(GetResponseEvent $event): void {
+    $request = $event->getRequest();
+    $response = $this->redirectFromNode('people', $request);
+
+    if ($response) {
+      $event->setResponse($response);
+    }
+  }
+
+  /**
+   * Redirect Studio canonical to Next/React page.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   A response for a request.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function isStudio(GetResponseEvent $event): void {
+    $request = $event->getRequest();
+    $response = $this->redirectFromNode('studio', $request);
+
+    if ($response) {
+      $event->setResponse($response);
+    }
+  }
+
+}

--- a/web/modules/custom/gos_site/src/UrlBuilderNextJs.php
+++ b/web/modules/custom/gos_site/src/UrlBuilderNextJs.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\gos_site;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Build URL from Drupal entity to Now.sh.
+ */
+class UrlBuilderNextJs {
+
+  /**
+   * NextJS URL patterns prefix to be used before the Drupal slug.
+   *
+   * @var array
+   */
+  public const NEXTJS_URLS_PREFIX = [
+    'game' => [
+      'fr' => '',
+      'en' => '',
+      'de' => '',
+    ],
+    'studio' => [
+      'fr' => '',
+      'en' => '',
+      'de' => '',
+    ],
+    'people' => [
+      'fr' => '',
+      'en' => '',
+      'de' => '',
+    ],
+  ];
+
+  /**
+   * The mocked configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * UrlBuilderNextJs constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Build a NextJS/React compliant Cardis URL.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityBase $entity
+   *   The entity to translate into a Next URL.
+   * @param \Symfony\Component\HttpFoundation\Request|null $request
+   *   The incoming request.
+   * @param string|null $langcode
+   *   An optional langcode to generate the link in a specific language.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   *
+   * @return string
+   *   The Next URL.
+   *
+   * @psalm-suppress TypeDoesNotContainType
+   */
+  public function buildUrl(ContentEntityBase $entity, ?Request $request = NULL, ?string $langcode = NULL): string {
+    /** @var string $bundle */
+    $bundle = $entity->bundle();
+
+    if (!isset(self::NEXTJS_URLS_PREFIX[$bundle])) {
+      throw new \InvalidArgumentException(sprintf('Bundle %s is not valid.', $bundle));
+    }
+
+    if (!$langcode) {
+      $langcode = $entity->language()->getId();
+    }
+
+    // To prevent a missing key error, throw an error if lang is not found.
+    if (!\array_key_exists($langcode, self::NEXTJS_URLS_PREFIX[$bundle])) {
+      throw new \InvalidArgumentException(sprintf('Langcode %s is not valid for %s.', $langcode, $bundle));
+    }
+
+    if (!$entity->hasTranslation($langcode)) {
+      throw new \InvalidArgumentException(sprintf('Node is not translated in %s.', $langcode));
+    }
+
+    $translation = $entity->getTranslation($langcode);
+
+    /** @var string $slug */
+    $slug = $translation->toUrl('canonical')->toString();
+    // Remove the langcode part as will be added manually later in the process.
+    $slug = str_replace("/{$langcode}", '', $slug);
+
+    // Build the complete destination path starting with the base URL.
+    $base_url = $this->configFactory->get('frontend')->get('base_url');
+    $dest = [$base_url];
+
+    // Add the language prefix /fr|/de|/it only when necessary.
+    if ($langcode !== 'en') {
+      $dest[] = $langcode;
+    }
+
+    // Finalize the URL building with translated prefix for Next routing.
+    if (!empty(self::NEXTJS_URLS_PREFIX[$bundle][$langcode])) {
+      $dest[] = self::NEXTJS_URLS_PREFIX[$bundle][$langcode];
+    }
+
+    $dest[] = trim($slug, '/');
+    $http_params = ($request && $request->query->count() > 0) ? '?' . http_build_query($request->query->all()) : NULL;
+
+    return implode('/', $dest) . $http_params;
+  }
+
+}

--- a/web/sites/default/development.settings.php
+++ b/web/sites/default/development.settings.php
@@ -20,6 +20,13 @@ $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = '9200
 $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = 'elasticsearch';
 
 /**
+ * Base URL of the Next App.
+ *
+ * This value should not contain a leading slash (/).
+ */
+$config['frontend']['base_url'] = 'https://gos.museebolo.ch';
+
+/**
  * Swiftmailer transport using mailcatcher.
  */
 $config['swiftmailer.transport']['transport'] = 'smtp';


### PR DESCRIPTION
### 💬 Describe the pull request

Be sure Games, Studios & People link from Drupal will redirect to React/Next decoupled website.

### 🗃️ Issues
This pull request is related to :
- close #100 

### 🔢 To Review
Steps to review the PR:
1. Access to a game canonical `/node/x`

### 🌩 Configuration to push on staging/prod

```
/**
 * Base URL of the Next App.
 *
 * This value should not contain a leading slash (/).
 *
 * @var string
 */
$config['frontend']['base_url'] = 'https://gos.museebolo.ch';
```