### PR TITLE
Set page size to 24 games instead of 25 in Elasticsearch

### DIFF
--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/resource/ElasticGamesResource.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/resource/ElasticGamesResource.php
@@ -42,7 +42,7 @@ class ElasticGamesResource extends ElasticResourceBase {
    *
    * @var string
    */
-  public const PAGER_SIZE = 25;
+  public const PAGER_SIZE = 24;
 
   /**
    * The taxonomy term Storage.


### PR DESCRIPTION
### 💬 Describe the pull request
I need a page size to be set to an even number dividable by 3 and 4. That way I can set a grid of 1-2-3-4 columns.

### 🗃️ Issues
This pull request is related to :
- none

### 🔢 To Review

click on "Merge pull request"

### 📸 Screenshots
If applicable, add screenshots to help explain the task.

### 🌩 API Swagger documentation
If applicable, add swagger API endpoints to help explain the usage.
