### PR TITLE
Serve webp images

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/field_group": "^3.0",
         "drupal/fieldable_path": "^1.0@RC",
         "drupal/focal_point": "^1.2",
+        "drupal/image_effects": "^3.0",
         "drupal/jsonapi_extras": "^3.13",
         "drupal/migrate_file": "^1.1",
         "drupal/migrate_source_csv": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "drupal/restui": "^1.18",
         "drupal/simple_sitemap": "^3.7",
         "drupal/views_ef_fieldset": "^1.4",
+        "drupal/webp": "^1.0@beta",
         "drush/drush": "^10.0",
         "sebastian/phpcpd": "^4.0",
         "vlucas/phpdotenv": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fded587a19f224f75d2d569dfec4c899",
+    "content-hash": "c939724a5a69b34bde83cb889df26ffa",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2927,6 +2927,124 @@
             }
         },
         {
+            "name": "drupal/file_mdm",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/file_mdm.git",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/file_mdm-8.x-2.1.zip",
+                "reference": "8.x-2.1",
+                "shasum": "5c3d75622299ebddc0e8456bb08bb371da8771bd"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "lsolesen/pel": "^0.9.8",
+                "phenx/php-font-lib": "^0.5.2",
+                "php": ">=7"
+            },
+            "require-dev": {
+                "drupal/image_effects": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1586801064",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a service to manage file metadata.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
+            "name": "drupal/file_mdm_exif",
+            "version": "2.1.0",
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "drupal/file_mdm": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1586801064",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a file metadata plugin for EXIF image information.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
+            "name": "drupal/file_mdm_font",
+            "version": "2.1.0",
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "drupal/file_mdm": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1586801064",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a file metadata plugin for TTF/OTF/WOFF font information.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
             "name": "drupal/focal_point",
             "version": "1.5.0",
             "source": {
@@ -2975,6 +3093,63 @@
                 "source": "https://cgit.drupalcode.org/focal_point",
                 "issues": "https://drupal.org/project/issues/focal_point",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/image_effects",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/image_effects.git",
+                "reference": "8.x-3.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/image_effects-8.x-3.0.zip",
+                "reference": "8.x-3.0",
+                "shasum": "583487575a28c4300917605de742bcf3af82a711"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "drupal/file_mdm_exif": "^2",
+                "drupal/file_mdm_font": "^2",
+                "php": ">=7.1"
+            },
+            "conflict": {
+                "drupal/imagemagick": "<3"
+            },
+            "require-dev": {
+                "drupal/imagemagick": "^3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.0",
+                    "datestamp": "1581702907",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Provides effects and operations for the Image API.",
+            "homepage": "https://www.drupal.org/project/image_effects",
+            "support": {
+                "source": "https://git.drupalcode.org/project/image_effects"
             }
         },
         {
@@ -4974,6 +5149,61 @@
             "time": "2020-09-05T08:40:12+00:00"
         },
         {
+            "name": "lsolesen/pel",
+            "version": "0.9.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pel/pel.git",
+                "reference": "92da891eaeeabbb00bcd09e0cea53796cf9ca967"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pel/pel/zipball/92da891eaeeabbb00bcd09e0cea53796cf9ca967",
+                "reference": "92da891eaeeabbb00bcd09e0cea53796cf9ca967",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "phpunit/phpunit": ">=4.8.36 <8",
+                "satooshi/php-coveralls": "1.0.*",
+                "squizlabs/php_codesniffer": "^3.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "lsolesen\\pel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Olesen",
+                    "email": "lars@intraface.dk",
+                    "homepage": "http://intraface.dk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Martin Geisler",
+                    "email": "martin@geisler.net",
+                    "homepage": "http://geisler.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Exif Library. A library for reading and writing Exif headers in JPEG and TIFF images using PHP.",
+            "homepage": "http://pel.github.com/pel/",
+            "keywords": [
+                "exif",
+                "image"
+            ],
+            "time": "2020-02-11T12:05:42+00:00"
+        },
+        {
             "name": "masterminds/html5",
             "version": "2.3.0",
             "source": {
@@ -5346,6 +5576,43 @@
                 "exception"
             ],
             "time": "2019-12-10T10:24:42+00:00"
+        },
+        {
+            "name": "phenx/php-font-lib",
+            "version": "0.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PhenX/php-font-lib.git",
+                "reference": "ca6ad461f032145fff5971b5985e5af9e7fa88d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PhenX/php-font-lib/zipball/ca6ad461f032145fff5971b5985e5af9e7fa88d8",
+                "reference": "ca6ad461f032145fff5971b5985e5af9e7fa88d8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5 || ^6 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/PhenX/php-font-lib",
+            "time": "2020-03-08T15:31:32+00:00"
         },
         {
             "name": "phpunit/php-timer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c939724a5a69b34bde83cb889df26ffa",
+    "content-hash": "91c09573e1f63410edf3e39b5ad59cc1",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3913,6 +3913,61 @@
             "homepage": "https://drupal.org/project/views_field_formatter",
             "support": {
                 "source": "https://git.drupalcode.org/project/views_ef_fieldset"
+            }
+        },
+        {
+            "name": "drupal/webp",
+            "version": "1.0.0-beta4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/webp.git",
+                "reference": "8.x-1.0-beta4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/webp-8.x-1.0-beta4.zip",
+                "reference": "8.x-1.0-beta4",
+                "shasum": "3327ef9e1f72c1aa779404c4977d67d5d910e96d"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "ext-gd": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-beta4",
+                    "datestamp": "1593334784",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Bart Vanhoutte",
+                    "homepage": "https://www.drupal.org/user/1133754",
+                    "email": "bart@croquemonsieur.be",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "alexmoreno",
+                    "homepage": "https://www.drupal.org/user/145609"
+                }
+            ],
+            "description": "Generates WebP copies of image style derivatives.",
+            "homepage": "https://www.drupal.org/project/webp",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/webp",
+                "issues": "https://www.drupal.org/project/issues/webp"
             }
         },
         {
@@ -13957,6 +14012,7 @@
         "drupal/elasticsearch_helper": 20,
         "drupal/fieldable_path": 5,
         "drupal/rabbit_hole": 10,
+        "drupal/webp": 10,
         "drupal/default_content": 15
     },
     "prefer-stable": true,

--- a/config/d8/sync/core.extension.yml
+++ b/config/d8/sync/core.extension.yml
@@ -66,6 +66,7 @@ module:
   user: 0
   views_ef_fieldset: 0
   views_ui: 0
+  webp: 0
   menu_link_content: 1
   pathauto: 1
   elasticsearch_helper: 10

--- a/config/d8/sync/core.extension.yml
+++ b/config/d8/sync/core.extension.yml
@@ -27,6 +27,9 @@ module:
   field_ui: 0
   fieldable_path: 0
   file: 0
+  file_mdm: 0
+  file_mdm_exif: 0
+  file_mdm_font: 0
   filter: 0
   focal_point: 0
   gos_elasticsearch: 0
@@ -36,6 +39,7 @@ module:
   help: 0
   history: 0
   image: 0
+  image_effects: 0
   jsonapi: 0
   jsonapi_extras: 0
   link: 0

--- a/config/d8/sync/file_mdm.file_metadata_plugin.getimagesize.yml
+++ b/config/d8/sync/file_mdm.file_metadata_plugin.getimagesize.yml
@@ -1,0 +1,9 @@
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI

--- a/config/d8/sync/file_mdm.settings.yml
+++ b/config/d8/sync/file_mdm.settings.yml
@@ -1,0 +1,6 @@
+metadata_cache:
+  enabled: true
+  expiration: 172800
+  disallowed_paths: {  }
+_core:
+  default_config_hash: Q8ZrmO8RU36KGMcNEaWFQOqYYO3z5Q4IZoS-xYy8MlA

--- a/config/d8/sync/file_mdm_exif.file_metadata_plugin.exif.yml
+++ b/config/d8/sync/file_mdm_exif.file_metadata_plugin.exif.yml
@@ -1,0 +1,35 @@
+ifd_map:
+  0:
+    type: 0
+    aliases:
+      - '0'
+      - IFD0
+      - Main
+  1:
+    type: 1
+    aliases:
+      - '1'
+      - IFD1
+      - Thumbnail
+  Exif:
+    type: 2
+    aliases:
+      - Exif
+  GPS:
+    type: 3
+    aliases:
+      - GPS
+  Interoperability:
+    type: 4
+    aliases:
+      - Interoperability
+      - Interop
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }
+_core:
+  default_config_hash: u0ZqkNrnyVSnHXGBP0zlKY9dP1ZARzJZ9VSovzU_eDg

--- a/config/d8/sync/file_mdm_font.file_metadata_plugin.font.yml
+++ b/config/d8/sync/file_mdm_font.file_metadata_plugin.font.yml
@@ -1,0 +1,9 @@
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI

--- a/config/d8/sync/image.style.placeholder_30x30.yml
+++ b/config/d8/sync/image.style.placeholder_30x30.yml
@@ -4,14 +4,22 @@ status: true
 dependencies:
   module:
     - focal_point
+    - image_effects
 name: placeholder_30x30
 label: placeholder_30x30
 effects:
   acab7233-2e84-43f0-9975-cb1e66513362:
     uuid: acab7233-2e84-43f0-9975-cb1e66513362
     id: focal_point_scale_and_crop
-    weight: null
+    weight: -10
     data:
       width: 30
       height: 30
       crop_type: focal_point
+  d04d4191-ad5d-400d-b4d2-259e04cf1cc1:
+    uuid: d04d4191-ad5d-400d-b4d2-259e04cf1cc1
+    id: image_effects_gaussian_blur
+    weight: 2
+    data:
+      radius: 3
+      sigma: null

--- a/config/d8/sync/image_effects.settings.yml
+++ b/config/d8/sync/image_effects.settings.yml
@@ -1,0 +1,14 @@
+color_selector:
+  plugin_id: html_color
+  plugin_settings:
+    html_color: {  }
+image_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }
+font_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }
+_core:
+  default_config_hash: eaXmaPSud65p-XhTwMIL9vKETD9zR3qNOMMa5EUuoNw

--- a/config/d8/sync/webp.settings.yml
+++ b/config/d8/sync/webp.settings.yml
@@ -1,0 +1,3 @@
+quality: 75
+_core:
+  default_config_hash: 0ube66wBYymHixNiMD-uyY8Tjo8alYV3NII6dv5iBJ8


### PR DESCRIPTION
### 💬 Describe the pull request

Webp image can be requested by using .webp as extension of existing IamgeStyles.

Example, `http://api.gos.test/sites/default/files/styles/downscale_675x500/public/games/2020-10/generateImage_eVPAAW.jpg?itok=27yEZ1cP` should be requested as `http://api.gos.test/sites/default/files/styles/downscale_675x500/public/games/2020-10/generateImage_eVPAAW.webp?itok=27yEZ1cP`

You can replace the `.jpg?` & `.webp?`.