### PR TITLE
Add a new filter `release_year_range` to `/search` endpoint

### DIFF
--- a/behat/Features/elasticsearch/search.games.release_year_range.feature
+++ b/behat/Features/elasticsearch/search.games.release_year_range.feature
@@ -1,0 +1,50 @@
+@elasticsearch
+  Feature: Retrieve Games items from Elasticsearch
+  In order to use a Games Search API
+  As a client software developer
+  I need to be able to filter by Starting/Endinf Release Year a JSON encoded resources from Elasticsearch via a Proxy
+
+  Scenario: Games Resource should respond with filtered games when a valid starting/ending year date (YYYY) are given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year_range[start]=2016&release_year_range[end]=2017"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 1 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | a0b7c853-c891-487f-84f9-74dfbce9fa63 |
+
+  Scenario: Games Resource should respond with filtered games when only a valid starting year date (YYYY) is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year_range[start]=2017"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 2 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON node "hits.hits[1]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | a0b7c853-c891-487f-84f9-74dfbce9fa63 |
+      | hits.hits[1]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
+
+  Scenario: Games Resource should respond with filtered games when only a valid ending year date (YYYY) is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year_range[end]=2018"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON node "hits.hits" should have 1 element
+    And the JSON node "hits.hits[0]._source" should exist
+    And the JSON node "hits.hits[1]._source" should exist
+    And the JSON nodes should be equal to:
+      | hits.hits[0]._source.uuid | a0b7c853-c891-487f-84f9-74dfbce9fa63 |
+      | hits.hits[1]._source.uuid | 08952aa6-e079-496a-8efa-cbb8465d9315 |
+
+  Scenario: Games Resource should respond with an error if the year end is higher than year start.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year_range[start]=2020&release_year_range[end]=2010"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the JSON node "errors.releaseYearRange" should exist
+    And the JSON node "errors.releaseYearRange[0]" should be equal to "The start release year can't be higher than the end release year."
+
+  Scenario: Games Resource should respond with an error with a non-valid surface range key is given.
+    Given I send a "GET" request to "http://api.gos.test/search/games?page=0&release_year_range[test]=2000"
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the JSON node "errors.releaseYearRange" should exist
+    And the JSON node "errors.releaseYearRange[0]" should be equal to "Please provide the start or end release year."

--- a/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
+++ b/web/modules/custom/gos_elasticsearch/src/Plugin/rest/ResourceValidator/ElasticGamesResourceValidator.php
@@ -100,6 +100,15 @@ class ElasticGamesResourceValidator extends BaseValidator {
   private $releaseYear;
 
   /**
+   * The game Release Year Range to filter by.
+   *
+   * This property uses the custom validation ::validateReleaseYearRange.
+   *
+   * @var array
+   */
+  private $releaseYearRange = [];
+
+  /**
    * Sort property with direction as key.
    *
    * This property uses the custom validation ::validateSort.
@@ -194,6 +203,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
    */
   public function getReleaseYear(): ?int {
     return $this->releaseYear;
+  }
+
+  /**
+   * Get the game Release year range to filter by.
+   *
+   * @return array
+   *   Year range.
+   */
+  public function getReleaseYearRange(): array {
+    return $this->releaseYearRange;
   }
 
   /**
@@ -297,6 +316,16 @@ class ElasticGamesResourceValidator extends BaseValidator {
   }
 
   /**
+   * Set the Release year range to filter by.
+   *
+   * @param array $year_range
+   *   Year range.
+   */
+  public function setReleaseYearRange(array $year_range): void {
+    $this->releaseYearRange = $year_range;
+  }
+
+  /**
    * Set the sort information.
    *
    * @param array $sort
@@ -382,6 +411,36 @@ class ElasticGamesResourceValidator extends BaseValidator {
     if (isset($this->raw['platforms']) && !$this->platforms) {
       $context->buildViolation(sprintf('At least one given Platform(s) has not been found.'))
         ->atPath('platforms')
+        ->addViolation();
+    }
+  }
+
+  /**
+   * Validates the release year range parameter.
+   *
+   * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
+   *   The validation execution context.
+   * @param string $payload
+   *   The Payload.
+   *
+   * @Assert\Callback
+   */
+  public function validateReleaseYearRange(ExecutionContextInterface $context, $payload): void {
+    if (!$this->releaseYearRange) {
+      $this->releaseYearRange = [];
+
+      return;
+    }
+
+    if (!\array_key_exists('start', $this->releaseYearRange) && !\array_key_exists('end', $this->releaseYearRange)) {
+      $context->buildViolation('Please provide the start or end release year.')
+        ->atPath('releaseYearRange')
+        ->addViolation();
+    }
+
+    if ((\array_key_exists('start', $this->releaseYearRange) && \array_key_exists('end', $this->releaseYearRange)) && ($this->releaseYearRange['start'] > $this->releaseYearRange['end'])) {
+      $context->buildViolation("The start release year can't be higher than the end release year.")
+        ->atPath('releaseYearRange')
         ->addViolation();
     }
   }

--- a/web/swagger/swagger.json
+++ b/web/swagger/swagger.json
@@ -168,6 +168,22 @@
             "example": "2019"
           },
           {
+            "name": "release_year_range[start]",
+            "in": "query",
+            "required": false,
+            "type": "number",
+            "description": "The year to filter games by starting date.",
+            "example": "2016"
+          },
+          {
+            "name": "release_year_range[end]",
+            "in": "query",
+            "required": false,
+            "type": "number",
+            "description": "The year to filter games by ending date.",
+            "example": "2020"
+          },
+          {
             "name": "states[]",
             "in": "query",
             "required": false,


### PR DESCRIPTION
### 💬 Describe the pull request

Add a new filter to allow "between" filter via Release Widget

<img width="337" alt="Screenshot 2020-11-05 at 13 58 32" src="https://user-images.githubusercontent.com/1841592/98244000-058eaf00-1f6f-11eb-87df-9e6cbf76f742.png">

### 🔢 To Review
Steps to review the PR:
1. http://api.gos.test/search/games?page=0&release_year_range[start]=2001&release_year_range[end]=2018

### 🌩 API Swagger documentation

New parameters `release_year_range[start]` & `release_year_range[end]`